### PR TITLE
refactor: replace tracing with log crate for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,13 +1547,13 @@ dependencies = [
  "bytes",
  "chrono",
  "config",
+ "log",
  "num_cpus",
  "resp",
  "storage",
  "telemetry",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2610,12 +2610,12 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "log",
  "object_store 0.13.1",
  "rstest",
  "slatedb",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
  "ulid",
 ]
 
@@ -2692,6 +2692,7 @@ name = "telemetry"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "log",
  "rstest",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = [
     "crates/resp",
     "crates/nimbis",
@@ -6,7 +7,6 @@ members = [
     "crates/storage",
     "crates/config",
 ]
-
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = "0.1.89"
 bytes = "1.11.0"
 chrono = "0.4.42"
 futures = "0.3.31"
+log = "0.4.29"
 num_cpus = "1.17.0"
 object_store = "0.13.0"
 quote = "1.0.43"
@@ -37,7 +38,7 @@ thiserror = "2.0.17"
 tokio = { version = "1.49.0", features = ["full"] }
 tracing = "0.1.44"
 tracing-appender = "0.2.4"
-tracing-subscriber = { version = "0.3.18", features = [
+tracing-subscriber = { version = "0.3.22", features = [
     "env-filter",
     "fmt",
     "registry",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,11 @@
+disallowed-macros = [
+    { path = "tracing::info", reason = "Use log::info instead" },
+    { path = "tracing::warn", reason = "Use log::warn instead" },
+    { path = "tracing::error", reason = "Use log::error instead" },
+    { path = "tracing::debug", reason = "Use log::debug instead" },
+    { path = "tracing::trace", reason = "Use log::trace instead" },
+    { path = "std::eprintln", reason = "Use log::error instead" },
+    { path = "std::eprint", reason = "Use log::error instead" },
+    { path = "std::println", reason = "Use log::info instead" },
+    { path = "std::print", reason = "Use log::info instead" },
+]

--- a/crates/nimbis/Cargo.toml
+++ b/crates/nimbis/Cargo.toml
@@ -16,7 +16,7 @@ arc-swap = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
+log = { workspace = true }
 num_cpus = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }

--- a/crates/nimbis/src/client.rs
+++ b/crates/nimbis/src/client.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::BytesMut;
+use log::debug;
 use resp::RespEncoder;
 use resp::RespParseResult;
 use resp::RespParser;
@@ -10,7 +11,6 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
-use tracing::debug;
 
 use crate::cmd::ParsedCmd;
 use crate::dispatcher::CommandDispatcher;

--- a/crates/nimbis/src/dispatcher.rs
+++ b/crates/nimbis/src/dispatcher.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use log::debug;
+use log::error;
 use resp::RespEncoder;
 use resp::RespValue;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tracing::debug;
-use tracing::error;
 
 use crate::cmd::ParsedCmd;
 use crate::worker::CmdRequest;

--- a/crates/nimbis/src/logo.rs
+++ b/crates/nimbis/src/logo.rs
@@ -5,6 +5,7 @@ pub const LOGO: &str = r#"
       █       ▐▙▄▞▘█
 "#;
 
+#[allow(clippy::disallowed_macros)]
 pub fn show_logo() {
 	let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
 

--- a/crates/nimbis/src/server.rs
+++ b/crates/nimbis/src/server.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use log::debug;
+use log::error;
+use log::info;
 use storage::Storage;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
-use tracing::debug;
-use tracing::error;
-use tracing::info;
 
 use crate::cmd::CmdTable;
 use crate::config::SERVER_CONF;

--- a/crates/nimbis/src/worker.rs
+++ b/crates/nimbis/src/worker.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use std::thread;
 
 use bytes::Bytes;
+use log::debug;
+use log::error;
+use log::warn;
 use resp::RespValue;
 use storage::Storage;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tracing::debug;
-use tracing::error;
-use tracing::warn;
 
 use crate::client::ClientSession;
 use crate::cmd::CmdTable;

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,11 +11,11 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+log = { workspace = true }
 object_store = { workspace = true }
 slatedb = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/storage/src/storage_list.rs
+++ b/crates/storage/src/storage_list.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use futures::future;
+use log::warn;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
 
@@ -325,7 +326,7 @@ impl Storage {
 				results.push(val);
 			} else {
 				// Should not happen if consistency is maintained
-				tracing::warn!(
+				warn!(
 					"List element missing for key {:?} at sequence. Potential data inconsistency.",
 					key
 				);

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -8,10 +8,11 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/telemetry/src/logger/mod.rs
+++ b/crates/telemetry/src/logger/mod.rs
@@ -51,7 +51,7 @@ static RELOAD_HANDLE: OnceLock<ReloadHandle> = OnceLock::new();
 ///
 /// ```no_run
 /// telemetry::init();
-/// tracing::info!("Server starting");
+/// log::info!("Server starting");
 /// ```
 pub fn init() {
 	// Create env filter with INFO as default level

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -47,11 +47,12 @@ var _ = Describe("CONFIG Commands", func() {
 		It("should get all fields with * wildcard", func() {
 			result, err := rdb.ConfigGet(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(HaveLen(4)) // addr, data_path, save, appendonly
+			Expect(result).To(HaveLen(5)) // addr, data_path, save, appendonly
 			Expect(result).To(HaveKeyWithValue("addr", "127.0.0.1:6379"))
 			Expect(result).To(HaveKeyWithValue("data_path", "./nimbis_data"))
 			Expect(result).To(HaveKeyWithValue("save", ""))
 			Expect(result).To(HaveKeyWithValue("appendonly", "no"))
+			Expect(result).To(HaveKeyWithValue("log_level", "info"))
 		})
 
 		It("should match fields with prefix wildcard", func() {


### PR DESCRIPTION
Switch from tracing to log crate macros (debug, error, info, warn) across all crates. The log crate provides better compatibility with various logging backends and simplifies the dependency graph.

Changes:
- Add log dependency to workspace and nimbis/storage/telemetry crates
- Replace tracing::{debug,error,info,warn} with log::*
- Update tracing-subscriber version in workspace Cargo.toml
- Add clippy.toml for clippy configuration