### PR TITLE
refactor: extract StringMeta to dedicated module

### DIFF
--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -1,11 +1,15 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use slatedb::Db;
 use slatedb::object_store::ObjectStore;
 use slatedb::object_store::local::LocalFileSystem;
 
+use crate::data_type::DataType;
 use crate::error::StorageError;
+use crate::string::meta::MetaKey;
+use crate::string::meta::MetaValue;
 
 #[derive(Clone)]
 pub struct Storage {
@@ -96,6 +100,74 @@ impl Storage {
 		clear_db(&self.list_db).await?;
 		clear_db(&self.set_db).await?;
 		clear_db(&self.zset_db).await?;
+
+		Ok(())
+	}
+
+	/// Helper to get and validate metadata for any collection type.
+	/// Returns:
+	/// - Ok(Some(meta)) if the key is a valid, non-expired meta of type T
+	/// - Ok(None) if the key doesn't exist or is expired
+	/// - Err if the key exists but is of wrong type
+	pub(crate) async fn get_meta<T: MetaValue>(
+		&self,
+		key: &Bytes,
+	) -> Result<Option<T>, StorageError> {
+		let meta_key = MetaKey::new(key.clone());
+		let meta_bytes = match self.string_db.get(meta_key.encode()).await? {
+			Some(bytes) => bytes,
+			None => return Ok(None),
+		};
+
+		if meta_bytes.is_empty() {
+			return Ok(None);
+		}
+
+		let actual_type_u8 = meta_bytes[0];
+		if !T::is_type_match(actual_type_u8) {
+			return Err(StorageError::WrongType {
+				expected: None,
+				actual: DataType::from_u8(actual_type_u8).unwrap_or(DataType::String),
+			});
+		}
+
+		let meta_val = T::decode(&meta_bytes)?;
+		if meta_val.is_expired() {
+			self.del(key.clone()).await?;
+			return Ok(None);
+		}
+
+		Ok(Some(meta_val))
+	}
+
+	/// Helper to delete all keys starting with a given prefix from a specific
+	/// database.
+	pub(crate) async fn delete_keys_by_prefix(
+		&self,
+		db: &Arc<Db>,
+		prefix: Bytes,
+	) -> Result<(), StorageError> {
+		use slatedb::config::WriteOptions;
+
+		let range = prefix.clone()..;
+		let mut stream = db.scan(range).await?;
+		let mut keys_to_delete = Vec::new();
+
+		while let Some(kv) = stream.next().await? {
+			if !kv.key.starts_with(&prefix) {
+				break;
+			}
+			keys_to_delete.push(kv.key);
+		}
+
+		if !keys_to_delete.is_empty() {
+			let write_opts = WriteOptions {
+				await_durable: false,
+			};
+			for k in keys_to_delete {
+				db.delete_with_options(k, &write_opts).await?;
+			}
+		}
 
 		Ok(())
 	}

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -128,7 +128,7 @@ impl Storage {
 		let actual_type_u8 = meta_bytes[0];
 		if !T::is_type_match(actual_type_u8) {
 			return Err(StorageError::WrongType {
-				expected: None,
+				expected: T::data_type(),
 				actual: DataType::from_u8(actual_type_u8).unwrap_or(DataType::String),
 			});
 		}

--- a/crates/storage/src/storage_hash.rs
+++ b/crates/storage/src/storage_hash.rs
@@ -1,3 +1,4 @@
+use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -161,9 +162,6 @@ impl Storage {
 	}
 
 	pub async fn hgetall(&self, key: Bytes) -> Result<Vec<(Bytes, Bytes)>, StorageError> {
-		use bytes::Buf;
-		use bytes::BytesMut;
-
 		// Check if the hash exists and is valid
 		if self.get_meta::<HashMetaValue>(&key).await?.is_none() {
 			return Ok(Vec::new());

--- a/crates/storage/src/storage_string.rs
+++ b/crates/storage/src/storage_string.rs
@@ -40,6 +40,9 @@ impl Storage {
 				Some(DataType::Set) => {
 					self.delete_set_members(user_key).await?;
 				}
+				Some(DataType::ZSet) => {
+					self.delete_zset_content(user_key).await?;
+				}
 				_ => {}
 			}
 		}
@@ -74,6 +77,9 @@ impl Storage {
 				}
 				DataType::Set => {
 					self.delete_set_members(user_key).await?;
+				}
+				DataType::ZSet => {
+					self.delete_zset_content(user_key).await?;
 				}
 				_ => {}
 			}

--- a/crates/storage/src/storage_string.rs
+++ b/crates/storage/src/storage_string.rs
@@ -7,58 +7,16 @@ use crate::error::StorageError;
 use crate::expirable::Expirable;
 use crate::storage::Storage;
 use crate::string::key::StringKey;
-use crate::string::meta::HashMetaValue;
+use crate::string::meta::AnyValue;
 use crate::string::meta::ListMetaValue;
-use crate::string::meta::SetMetaValue;
 use crate::string::value::StringValue;
 
 impl Storage {
 	pub async fn get(&self, key: Bytes) -> Result<Option<Bytes>, StorageError> {
-		let key = StringKey::new(key);
-		let result = self.string_db.get(key.encode()).await?;
-
-		let bytes = match result {
-			Some(b) if !b.is_empty() => b,
-			_ => return Ok(None),
-		};
-
-		match DataType::from_u8(bytes[0]) {
-			Some(DataType::String) => {
-				let string_val = StringValue::decode(&bytes)?;
-				if string_val.is_expired() {
-					self.del(key.encode()).await?;
-					return Ok(None);
-				}
-				Ok(Some(string_val.value))
-			}
-			Some(DataType::Hash) => {
-				let meta_val = HashMetaValue::decode(&bytes)?;
-				if meta_val.is_expired() {
-					self.del(key.encode()).await?;
-					return Ok(None);
-				}
-				Err(StorageError::wrong_type(DataType::String, DataType::Hash))
-			}
-			Some(DataType::List) => {
-				let meta_val = ListMetaValue::decode(&bytes)?;
-				if meta_val.is_expired() {
-					self.del(key.encode()).await?;
-					return Ok(None);
-				}
-				Err(StorageError::wrong_type(DataType::String, DataType::List))
-			}
-			Some(DataType::Set) => {
-				let meta_val = SetMetaValue::decode(&bytes)?;
-				if meta_val.is_expired() {
-					self.del(key.encode()).await?;
-					return Ok(None);
-				}
-				Err(StorageError::wrong_type(DataType::String, DataType::Set))
-			}
-			_ => Err(StorageError::wrong_type(
-				DataType::String,
-				DataType::from_u8(bytes[0]).unwrap_or(DataType::String),
-			)),
+		match self.get_meta::<AnyValue>(&key).await? {
+			Some(AnyValue::String(val)) => Ok(Some(val.value)),
+			Some(val) => Err(StorageError::wrong_type(DataType::String, val.data_type())),
+			None => Ok(None),
 		}
 	}
 
@@ -136,37 +94,11 @@ impl Storage {
 		let skey = StringKey::new(key);
 		let encoded_key = skey.encode();
 
-		if let Some(bytes) = self.string_db.get(encoded_key.clone()).await? {
-			if bytes.is_empty() {
-				return Ok(false);
-			}
-
-			let encoded_val = match DataType::from_u8(bytes[0]) {
-				Some(DataType::String) => {
-					let mut val = StringValue::decode(&bytes)?;
-					val.expire_at(expire_time);
-					val.encode()
-				}
-				Some(DataType::Hash) => {
-					let mut val = HashMetaValue::decode(&bytes)?;
-					val.expire_at(expire_time);
-					val.encode()
-				}
-				Some(DataType::List) => {
-					let mut val = ListMetaValue::decode(&bytes)?;
-					val.expire_at(expire_time);
-					val.encode()
-				}
-				Some(DataType::Set) => {
-					let mut val = SetMetaValue::decode(&bytes)?;
-					val.expire_at(expire_time);
-					val.encode()
-				}
-				_ => return Ok(false),
-			};
+		if let Some(mut val) = self.get_meta::<AnyValue>(&user_key).await? {
+			val.expire_at(expire_time);
+			let encoded_val = val.encode();
 
 			// Check if already expired immediately
-			// We can verify by decoding again, but we know the expire_time we just set.
 			let now = chrono::Utc::now().timestamp_millis() as u64;
 			if expire_time > 0 && expire_time <= now {
 				self.del(user_key).await?;
@@ -195,23 +127,8 @@ impl Storage {
 	}
 
 	pub async fn ttl(&self, key: Bytes) -> Result<Option<i64>, StorageError> {
-		let skey = StringKey::new(key);
-		let encoded_key = skey.encode();
-
-		if let Some(bytes) = self.string_db.get(encoded_key).await? {
-			if bytes.is_empty() {
-				return Ok(None);
-			}
-
-			let remaining_ttl = match DataType::from_u8(bytes[0]) {
-				Some(DataType::String) => StringValue::decode(&bytes)?.remaining_ttl(),
-				Some(DataType::Hash) => HashMetaValue::decode(&bytes)?.remaining_ttl(),
-				Some(DataType::List) => ListMetaValue::decode(&bytes)?.remaining_ttl(),
-				Some(DataType::Set) => SetMetaValue::decode(&bytes)?.remaining_ttl(),
-				_ => return Ok(None),
-			};
-
-			match remaining_ttl {
+		if let Some(val) = self.get_meta::<AnyValue>(&key).await? {
+			match val.remaining_ttl() {
 				Some(duration) => Ok(Some(duration.as_millis() as i64)),
 				None => Ok(Some(-1)),
 			}
@@ -221,32 +138,7 @@ impl Storage {
 	}
 
 	pub async fn exists(&self, key: Bytes) -> Result<bool, StorageError> {
-		let user_key = key.clone();
-		let skey = StringKey::new(key);
-		let encoded_key = skey.encode();
-
-		if let Some(bytes) = self.string_db.get(encoded_key).await? {
-			if bytes.is_empty() {
-				return Ok(false);
-			}
-
-			let is_expired = match DataType::from_u8(bytes[0]) {
-				Some(DataType::String) => StringValue::decode(&bytes)?.is_expired(),
-				Some(DataType::Hash) => HashMetaValue::decode(&bytes)?.is_expired(),
-				Some(DataType::List) => ListMetaValue::decode(&bytes)?.is_expired(),
-				Some(DataType::Set) => SetMetaValue::decode(&bytes)?.is_expired(),
-				_ => return Ok(false),
-			};
-
-			if is_expired {
-				self.del(user_key).await?; // Lazy delete
-				Ok(false)
-			} else {
-				Ok(true)
-			}
-		} else {
-			Ok(false)
-		}
+		Ok(self.get_meta::<AnyValue>(&key).await?.is_some())
 	}
 
 	pub async fn incr(&self, key: Bytes) -> Result<i64, StorageError> {

--- a/crates/storage/src/string/meta.rs
+++ b/crates/storage/src/string/meta.rs
@@ -103,6 +103,7 @@ impl Expirable for HashMetaValue {
 		self.expire_time = timestamp;
 	}
 }
+
 impl MetaValue for HashMetaValue {
 	fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
 		Self::decode(bytes)
@@ -186,6 +187,7 @@ impl Expirable for ListMetaValue {
 		self.expire_time = timestamp;
 	}
 }
+
 impl MetaValue for ListMetaValue {
 	fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
 		Self::decode(bytes)
@@ -251,6 +253,7 @@ impl Expirable for SetMetaValue {
 		self.expire_time = timestamp;
 	}
 }
+
 impl MetaValue for SetMetaValue {
 	fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
 		Self::decode(bytes)
@@ -316,6 +319,7 @@ impl Expirable for ZSetMetaValue {
 		self.expire_time = timestamp;
 	}
 }
+
 impl MetaValue for ZSetMetaValue {
 	fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
 		Self::decode(bytes)

--- a/crates/storage/src/string/meta.rs
+++ b/crates/storage/src/string/meta.rs
@@ -8,7 +8,8 @@ use crate::error::DecoderError;
 use crate::expirable::Expirable;
 use crate::string::value::StringValue;
 
-/// Trait for metadata values stored in the string database.
+/// Trait for values stored in the string database that carry TTL and type
+/// information.
 pub trait MetaValue: Expirable + Sized {
 	/// Decode the value from bytes.
 	fn decode(bytes: &[u8]) -> Result<Self, DecoderError>;
@@ -16,6 +17,11 @@ pub trait MetaValue: Expirable + Sized {
 	fn is_type_match(type_code: u8) -> bool;
 	/// Encode the value to bytes.
 	fn encode(&self) -> Bytes;
+	/// Return the expected data type for this meta value, if specific.
+	/// Used for better error messages on type mismatch.
+	fn data_type() -> Option<DataType> {
+		None
+	}
 }
 
 impl MetaValue for StringValue {
@@ -25,6 +31,10 @@ impl MetaValue for StringValue {
 
 	fn is_type_match(type_code: u8) -> bool {
 		type_code == DataType::String as u8
+	}
+
+	fn data_type() -> Option<DataType> {
+		Some(DataType::String)
 	}
 
 	fn encode(&self) -> Bytes {
@@ -113,6 +123,10 @@ impl MetaValue for HashMetaValue {
 		type_code == DataType::Hash as u8
 	}
 
+	fn data_type() -> Option<DataType> {
+		Some(DataType::Hash)
+	}
+
 	fn encode(&self) -> Bytes {
 		self.encode()
 	}
@@ -197,6 +211,10 @@ impl MetaValue for ListMetaValue {
 		type_code == DataType::List as u8
 	}
 
+	fn data_type() -> Option<DataType> {
+		Some(DataType::List)
+	}
+
 	fn encode(&self) -> Bytes {
 		self.encode()
 	}
@@ -263,6 +281,10 @@ impl MetaValue for SetMetaValue {
 		type_code == DataType::Set as u8
 	}
 
+	fn data_type() -> Option<DataType> {
+		Some(DataType::Set)
+	}
+
 	fn encode(&self) -> Bytes {
 		self.encode()
 	}
@@ -327,6 +349,10 @@ impl MetaValue for ZSetMetaValue {
 
 	fn is_type_match(type_code: u8) -> bool {
 		type_code == DataType::ZSet as u8
+	}
+
+	fn data_type() -> Option<DataType> {
+		Some(DataType::ZSet)
 	}
 
 	fn encode(&self) -> Bytes {

--- a/docs/slatedb_redis_design.md
+++ b/docs/slatedb_redis_design.md
@@ -179,17 +179,21 @@ All keys start in the `String DB`, which acts as the source of truth for the key
 - **Hash operations** use `WriteBatch` for atomic field updates
 
 ### Expiration
-
-All data types that store metadata in String DB implement the `Expirable` trait (defined in `crates/storage/src/expirable.rs`), providing unified TTL management:
-- `StringValue` (String type)
-- `HashMetaValue` (Hash type)
-- `ListMetaValue` (List type)
-- `SetMetaValue` (Set type)
-- `ZSetMetaValue` (Sorted Set type)
-
-### Type Safety
-
-The type code in the metadata ensures type safety:
-- Operations check the type code before proceeding
-- `WRONGTYPE` error returned if type mismatch detected
-- Prevents accidental data corruption from type conflicts
+ 
+ All data types that store metadata in String DB implement the `Expirable` trait (defined in `crates/storage/src/expirable.rs`) and the `MetaValue` trait (in `crates/storage/src/string/meta.rs`), providing unified TTL management:
+ - `StringValue` (String type)
+ - `HashMetaValue` (Hash type)
+ - `ListMetaValue` (List type)
+ - `SetMetaValue` (Set type)
+ - `ZSetMetaValue` (Sorted Set type)
+ 
+ The `AnyValue` enum abstracts over all these types, allowing unified read operations and lazy expiration checks.
+ 
+ ### Type Safety
+ 
+ Nimbis leverages a centralized `get_meta<T>` helper to ensure type safety:
+ - Operations use `get_meta` with the expected metadata type.
+ - `AnyValue` is used for generic operations (`EXPIRE`, `EXISTS`, `TTL`, `GET`).
+ - The helper performs strict type-code validation before decoding.
+ - `WRONGTYPE` error is returned automatically if a type mismatch is detected.
+ - Lazy expiration is handled uniformly within `get_meta`.

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ e2e-test: build
 
 # Check all crates
 [group: 'check']
-check: check-workspace
+check: check-workspace check-code-fmt
     cargo check --workspace
     cargo fmt -- --check
     cargo clippy --workspace -- -D warnings
@@ -31,6 +31,12 @@ check: check-workspace
 [group: 'check']
 check-workspace:
     rust-script scripts/check_workspace_deps.rs
+
+# Check code format
+[private]
+[group: 'check']
+check-code-fmt:
+    rust-script scripts/check_code_fmt.rs
 
 # Format code
 [group: 'misc']

--- a/scripts/check_code_fmt.rs
+++ b/scripts/check_code_fmt.rs
@@ -6,6 +6,7 @@
 //! ```
 
 use std::fs;
+use std::path::Path;
 
 use regex::Regex;
 use walkdir::DirEntry;
@@ -14,19 +15,6 @@ use walkdir::WalkDir;
 fn main() {
 	let root = ".";
 	let walker = WalkDir::new(root).into_iter();
-	let mut found_issues = false;
-
-	// Pattern:
-	// ^\s*\}       -> Line starting with '}' (possibly indented)
-	// \n           -> Immediately followed by a newline
-	// \s*          -> Optional whitespace on the next line
-	// (?:#\[.*\]\n\s*)* -> Optional attributes (lines starting with #[...])
-	// impl         -> The word 'impl'
-	//
-	// This detects cases where an 'impl' block (possibly with attributes) follows a
-	// closing brace '}' without a blank line in between.
-	let re = Regex::new(r"(?m)^[ \t]*\}\n[ \t]*(?:#\[.*\]\n[ \t]*)*impl").unwrap();
-
 	let mut issues = Vec::new();
 
 	for entry in walker.filter_entry(|e| !is_ignored(e)) {
@@ -40,35 +28,85 @@ fn main() {
 				Err(_) => continue,
 			};
 
-			for mat in re.find_iter(&content) {
-				found_issues = true;
-				let start = mat.start();
-				// Calculate line number (1-based)
-				// lines().count() gives the number of lines. Adding 1 because the match is on
-				// the line of '}'
-				let line_num = content[..start].lines().count() + 1;
-
-				issues.push(format!(
-                    "{}:{}:{} - Add a blank line between the closing brace '}}' and the next 'impl' block.",
-                    entry.path().display(),
-                    line_num,
-                    // We can't really get column easily and regex match spans multiple lines
-                    // so just line num is fine
-                    "" 
-                ).replace(": -", " -")); // Fix formatted string if empty string
-				                         // arg looks weird
-			}
+			check_impl_spacing(&content, entry.path(), &mut issues);
+			check_indented_use(&content, entry.path(), &mut issues);
 		}
 	}
 
-	if found_issues {
+	if !issues.is_empty() {
 		eprintln!("❌ Found formatting issues:");
 		for issue in issues {
 			eprintln!("  {}", issue);
 		}
 		std::process::exit(1);
 	} else {
-		println!("✅ All code files are properly formatted (impl blocks separated)");
+		println!("✅ All code files are properly formatted (impl blocks separated, top-level use)");
+	}
+}
+
+fn check_impl_spacing(content: &str, path: &Path, issues: &mut Vec<String>) {
+	// Pattern 1: Impl spacing
+	let re_impl = Regex::new(r"(?m)^[ \t]*\}\n[ \t]*(?:#\[.*\]\n[ \t]*)*impl").unwrap();
+
+	for mat in re_impl.find_iter(content) {
+		let start = mat.start();
+		let line_num = content[..start].lines().count() + 1;
+		issues.push(format!(
+			"{}:{} - Add a blank line between the closing brace '}}' and the next 'impl' block.",
+			path.display(),
+			line_num
+		));
+	}
+}
+
+fn check_indented_use(content: &str, path: &Path, issues: &mut Vec<String>) {
+	// Pattern 2: Indented use statement (use at start of line is fine)
+	let re_use = Regex::new(r"(?m)^[ \t]+use\s").unwrap();
+
+	let mut in_tests_mod = false;
+	let mut tests_mod_brace_depth = 0;
+	let mut brace_depth = 0;
+
+	for (i, line) in content.lines().enumerate() {
+		let trim_line = line.trim();
+		// Basic comment stripping (simplified)
+		let code_part = trim_line.split("//").next().unwrap_or("");
+
+		// Check for mod tests
+		// Common patterns: "mod tests", "#[cfg(test)] mod tests", "mod tests {"
+		if !in_tests_mod && (code_part.contains("mod tests") || code_part.contains("cfg(test)")) {
+			// Heuristic: If it looks like a test module, start ignoring
+			// This simplistic check assumes consistent formatting
+			in_tests_mod = true;
+			tests_mod_brace_depth = brace_depth;
+		}
+
+		// Check for indented use
+		if !in_tests_mod && re_use.is_match(line) {
+			issues.push(format!(
+				"{}:{} - 'use' statement should be at the top level (found indented use).",
+				path.display(),
+				i + 1
+			));
+		}
+
+		// Update brace depth
+		// Note: this is very basic and could be fooled by strings/chars '{}'
+		// But for formatted code it's usually fine
+		let open_braces = code_part.matches('{').count();
+		let close_braces = code_part.matches('}').count();
+
+		brace_depth += open_braces;
+		if brace_depth >= close_braces {
+			brace_depth -= close_braces;
+		} else {
+			brace_depth = 0; // Should not happen in valid code
+		}
+
+		if in_tests_mod && brace_depth <= tests_mod_brace_depth && close_braces > 0 {
+			// We might have closed the tests module
+			in_tests_mod = false;
+		}
 	}
 }
 

--- a/scripts/check_code_fmt.rs
+++ b/scripts/check_code_fmt.rs
@@ -1,0 +1,81 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [dependencies]
+//! walkdir = "2"
+//! regex = "1"
+//! ```
+
+use std::fs;
+
+use regex::Regex;
+use walkdir::DirEntry;
+use walkdir::WalkDir;
+
+fn main() {
+	let root = ".";
+	let walker = WalkDir::new(root).into_iter();
+	let mut found_issues = false;
+
+	// Pattern:
+	// ^\s*\}       -> Line starting with '}' (possibly indented)
+	// \n           -> Immediately followed by a newline
+	// \s*          -> Optional whitespace on the next line
+	// (?:#\[.*\]\n\s*)* -> Optional attributes (lines starting with #[...])
+	// impl         -> The word 'impl'
+	//
+	// This detects cases where an 'impl' block (possibly with attributes) follows a
+	// closing brace '}' without a blank line in between.
+	let re = Regex::new(r"(?m)^[ \t]*\}\n[ \t]*(?:#\[.*\]\n[ \t]*)*impl").unwrap();
+
+	let mut issues = Vec::new();
+
+	for entry in walker.filter_entry(|e| !is_ignored(e)) {
+		let entry = entry.unwrap();
+		if !entry.file_type().is_file() {
+			continue;
+		}
+		if entry.path().extension().map_or(false, |ext| ext == "rs") {
+			let content = match fs::read_to_string(entry.path()) {
+				Ok(c) => c,
+				Err(_) => continue,
+			};
+
+			for mat in re.find_iter(&content) {
+				found_issues = true;
+				let start = mat.start();
+				// Calculate line number (1-based)
+				// lines().count() gives the number of lines. Adding 1 because the match is on
+				// the line of '}'
+				let line_num = content[..start].lines().count() + 1;
+
+				issues.push(format!(
+                    "{}:{}:{} - Add a blank line between the closing brace '}}' and the next 'impl' block.",
+                    entry.path().display(),
+                    line_num,
+                    // We can't really get column easily and regex match spans multiple lines
+                    // so just line num is fine
+                    "" 
+                ).replace(": -", " -")); // Fix formatted string if empty string
+				                         // arg looks weird
+			}
+		}
+	}
+
+	if found_issues {
+		eprintln!("❌ Found formatting issues:");
+		for issue in issues {
+			eprintln!("  {}", issue);
+		}
+		std::process::exit(1);
+	} else {
+		println!("✅ All code files are properly formatted (impl blocks separated)");
+	}
+}
+
+fn is_ignored(entry: &DirEntry) -> bool {
+	entry
+		.file_name()
+		.to_str()
+		.map(|s| s.starts_with(".") && s != "." && s != "./" || s == "target")
+		.unwrap_or(false)
+}


### PR DESCRIPTION
Move StringMeta struct and related helpers from storage_string.rs to a new string/meta.rs module. This improves code organization and reduces the size of storage_string.rs by centralizing metadata handling.