### PR TITLE
feat(storage): add FoyerCache for memory caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ memchr = "2.7.6"
 num_cpus = "1.17.0"
 object_store = "0.13.1"
 quote = "1.0.43"
-slatedb = "0.10.1"
+slatedb = { version = "0.10.1", features = ["foyer"] }
 syn = { version = "2.0.114", features = ["full"] }
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -55,11 +55,15 @@ impl Storage {
 
 		let object_store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new_with_prefix(path)?);
 
+		// Create a single shared cache for all databases in this shard
+		let cache = Arc::new(FoyerCache::new());
+
 		let open_db = |name: &'static str| {
 			let store = object_store.clone();
+			let cache = cache.clone();
 			async move {
 				Db::builder(slatedb::object_store::path::Path::from(name), store)
-					.with_memory_cache(Arc::new(FoyerCache::new()))
+					.with_memory_cache(cache)
 					.build()
 					.await
 			}


### PR DESCRIPTION
Enable foyer feature in slatedb and integrate FoyerCache as the memory cache layer for all database instances.