### PR TITLE
feat(storage): implement compaction filter and version generator for …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ object_store = "0.13.1"
 quote = "1.0.44"
 slatedb = { git = "https://github.com/slatedb/slatedb.git", rev = "b1e9e7a63b2bd174b3b43b79681640ce9c4baec4", features = [
     "foyer",
+    "compaction_filters",
 ] }
 syn = { version = "2.0.114", features = ["full"] }
 thiserror = "2.0.18"

--- a/crates/storage/src/compaction_filter.rs
+++ b/crates/storage/src/compaction_filter.rs
@@ -1,0 +1,287 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Buf;
+use bytes::Bytes;
+use slatedb::CompactionFilter;
+use slatedb::CompactionFilterDecision;
+use slatedb::CompactionFilterError;
+use slatedb::CompactionFilterSupplier;
+use slatedb::CompactionJobContext;
+use slatedb::Db;
+use slatedb::RowEntry;
+use slatedb::ValueDeletable;
+
+use crate::data_type::DataType;
+use crate::expirable::Expirable;
+use crate::string::meta::AnyValue;
+use crate::string::meta::MetaKey;
+
+pub struct NimbisCompactionFilter {
+	string_db: Option<Arc<Db>>,
+	data_type: DataType,
+}
+
+impl NimbisCompactionFilter {
+	fn decode_sub_key(key: &[u8]) -> Option<(Bytes, u64)> {
+		if key.len() < 2 {
+			return None;
+		}
+		let mut buf = key;
+		let key_len = buf.get_u16() as usize;
+		if buf.len() < key_len + 8 {
+			return None;
+		}
+		let user_key = Bytes::copy_from_slice(&buf[..key_len]);
+		buf.advance(key_len);
+		let version = buf.get_u64();
+		Some((user_key, version))
+	}
+}
+
+#[async_trait]
+impl CompactionFilter for NimbisCompactionFilter {
+	async fn filter(
+		&mut self,
+		entry: &RowEntry,
+	) -> Result<CompactionFilterDecision, CompactionFilterError> {
+		// We only care about entries that are not already tombstones
+		let bytes = match &entry.value {
+			ValueDeletable::Value(bytes) | ValueDeletable::Merge(bytes) => bytes,
+			ValueDeletable::Tombstone => return Ok(CompactionFilterDecision::Keep),
+		};
+
+		match self.data_type {
+			DataType::String => {
+				// String DB: Check TTL in value
+				let any_val = match AnyValue::decode(bytes) {
+					Ok(val) => val,
+					Err(_) => return Ok(CompactionFilterDecision::Keep),
+				};
+
+				if any_val.is_expired() {
+					return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+				}
+				Ok(CompactionFilterDecision::Keep)
+			}
+			_ => {
+				// Collection DB: Check metadata in string_db
+				let Some(string_db) = &self.string_db else {
+					// Should not happen if configured correctly
+					return Ok(CompactionFilterDecision::Keep);
+				};
+
+				// Decode sub-key to getKey and Version
+				let Some((user_key, version)) = Self::decode_sub_key(&entry.key) else {
+					// Invalid key format? Keep safe.
+					return Ok(CompactionFilterDecision::Keep);
+				};
+
+				// Lookup metadata
+				let meta_key = MetaKey::new(user_key);
+				let meta_encoded = match string_db.get(meta_key.encode()).await {
+					Ok(Some(v)) => v,
+					Ok(None) => {
+						// Metadata missing -> Orphaned sub-key -> Delete
+						return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+					}
+					Err(_) => return Ok(CompactionFilterDecision::Keep), // Error -> Keep safe
+				};
+
+				let any_val = match AnyValue::decode(&meta_encoded) {
+					Ok(v) => v,
+					Err(_) => return Ok(CompactionFilterDecision::Keep),
+				};
+
+				// Check expiration
+				if any_val.is_expired() {
+					return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+				}
+
+				// Check Type and Version
+				match any_val {
+					AnyValue::Hash(m) if self.data_type == DataType::Hash => {
+						if m.version != version {
+							return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+						}
+					}
+					AnyValue::List(m) if self.data_type == DataType::List => {
+						if m.version != version {
+							return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+						}
+					}
+					AnyValue::Set(m) if self.data_type == DataType::Set => {
+						if m.version != version {
+							return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+						}
+					}
+					AnyValue::ZSet(m) if self.data_type == DataType::ZSet => {
+						if m.version != version {
+							return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+						}
+					}
+					_ => {
+						// Type mismatch -> Orphaned sub-key (collision) -> Delete
+						return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+					}
+				}
+
+				Ok(CompactionFilterDecision::Keep)
+			}
+		}
+	}
+
+	async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+		Ok(())
+	}
+}
+
+pub struct NimbisCompactionFilterSupplier {
+	pub string_db: Option<Arc<Db>>,
+	pub data_type: DataType,
+}
+
+#[async_trait]
+impl CompactionFilterSupplier for NimbisCompactionFilterSupplier {
+	async fn create_compaction_filter(
+		&self,
+		_context: &CompactionJobContext,
+	) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
+		Ok(Box::new(NimbisCompactionFilter {
+			string_db: self.string_db.clone(),
+			data_type: self.data_type,
+		}))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bytes::Bytes;
+	use slatedb::ValueDeletable;
+
+	use super::*;
+	use crate::string::value::StringValue;
+
+	#[tokio::test]
+	async fn test_filter_expired_key() {
+		let mut filter = NimbisCompactionFilter {
+			string_db: None,
+			data_type: DataType::String,
+		};
+		let value = StringValue::new_with_ttl(Bytes::from("val"), 100);
+		let entry = RowEntry {
+			key: Bytes::from("key"),
+			value: ValueDeletable::Value(value.encode()),
+			seq: 1,
+			create_ts: None,
+			expire_ts: None,
+		};
+
+		// Mock current time > 100
+		let decision = filter.filter(&entry).await.unwrap();
+		// Since we use Utc::now() in AnyValue::is_expired(), we need to make sure 100
+		// is past. 100ms since epoch is definitely in the past.
+		assert_eq!(
+			decision,
+			CompactionFilterDecision::Modify(ValueDeletable::Tombstone)
+		);
+	}
+
+	#[tokio::test]
+	async fn test_filter_not_expired_key() {
+		let mut filter = NimbisCompactionFilter {
+			string_db: None,
+			data_type: DataType::String,
+		};
+		let future_time = (chrono::Utc::now().timestamp_millis() + 100000) as u64;
+		let value = StringValue::new_with_ttl(Bytes::from("val"), future_time);
+		let entry = RowEntry {
+			key: Bytes::from("key"),
+			value: ValueDeletable::Value(value.encode()),
+			seq: 1,
+			create_ts: None,
+			expire_ts: None,
+		};
+
+		let decision = filter.filter(&entry).await.unwrap();
+		assert_eq!(decision, CompactionFilterDecision::Keep);
+	}
+
+	#[tokio::test]
+	async fn test_filter_version_mismatch() {
+		use std::sync::Arc;
+
+		use bytes::BufMut;
+		use bytes::BytesMut;
+		use slatedb::Db;
+		use slatedb::object_store::local::LocalFileSystem;
+		use slatedb::object_store::path::Path;
+
+		use crate::string::meta::HashMetaValue;
+
+		// 1. Setup string_db using local temp dir
+		let temp_dir = std::env::temp_dir().join(format!("nimbis-test-{}", ulid::Ulid::new()));
+		tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+		let object_store = Arc::new(LocalFileSystem::new_with_prefix(&temp_dir).unwrap());
+
+		let string_db = Db::builder(Path::from("/string"), object_store)
+			.build()
+			.await
+			.unwrap();
+		let string_db = Arc::new(string_db);
+
+		// 2. Put Metadata (version 10)
+		let user_key = Bytes::from("myhash");
+		let meta_key = MetaKey::new(user_key.clone());
+		let meta_val = HashMetaValue::new(10, 5);
+		string_db
+			.put(meta_key.encode(), meta_val.encode())
+			.await
+			.unwrap();
+
+		// 3. Setup Filter
+		let mut filter = NimbisCompactionFilter {
+			string_db: Some(string_db.clone()),
+			data_type: DataType::Hash,
+		};
+
+		// 4. Test Valid Version (10)
+		// SubKey: len(2) + key + version(8) + field_len(4) + field
+		let mut valid_key = BytesMut::new();
+		valid_key.put_u16(user_key.len() as u16);
+		valid_key.extend_from_slice(&user_key);
+		valid_key.put_u64(10); // Matches
+		valid_key.put_u32(5); // field len
+		valid_key.put_slice(b"field");
+		let valid_entry = RowEntry {
+			key: valid_key.freeze(),
+			value: ValueDeletable::Value(Bytes::from("val")),
+			seq: 1,
+			create_ts: None,
+			expire_ts: None,
+		};
+		assert_eq!(
+			filter.filter(&valid_entry).await.unwrap(),
+			CompactionFilterDecision::Keep
+		);
+
+		// 5. Test Invalid Version (9)
+		let mut invalid_key = BytesMut::new();
+		invalid_key.put_u16(user_key.len() as u16);
+		invalid_key.extend_from_slice(&user_key);
+		invalid_key.put_u64(9); // Mismatch!
+		invalid_key.put_u32(5);
+		invalid_key.put_slice(b"field");
+		let invalid_entry = RowEntry {
+			key: invalid_key.freeze(),
+			value: ValueDeletable::Value(Bytes::from("val")),
+			seq: 2,
+			create_ts: None,
+			expire_ts: None,
+		};
+		assert_eq!(
+			filter.filter(&invalid_entry).await.unwrap(),
+			CompactionFilterDecision::Modify(ValueDeletable::Tombstone)
+		);
+	}
+}

--- a/crates/storage/src/compaction_filter.rs
+++ b/crates/storage/src/compaction_filter.rs
@@ -79,7 +79,7 @@ impl CompactionFilter for NimbisCompactionFilter {
 					return Ok(CompactionFilterDecision::Keep);
 				};
 
-				// Decode sub-key to getKey and Version
+				// Decode sub-key to get user_key and version
 				let Some((user_key, version)) = Self::decode_sub_key(&entry.key) else {
 					// Invalid key format? Keep safe.
 					debug!(

--- a/crates/storage/src/hash/field_key.rs
+++ b/crates/storage/src/hash/field_key.rs
@@ -5,27 +5,41 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct HashFieldKey {
 	user_key: Bytes,
+	version: u64,
 	field: Bytes,
 }
 
 impl HashFieldKey {
-	pub fn new(user_key: impl Into<Bytes>, field: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, field: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			version,
 			field: field.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + len(field) (u32 BE) + field
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + len(field)
+		// (u32 BE) + field
 		let field_len = self.field.len() as u32;
 
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 4 + self.field.len());
+		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.field.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.version);
 		bytes.put_u32(field_len);
 		bytes.extend_from_slice(&self.field);
 		bytes.freeze()
+	}
+
+	/// Returns the user_key from this field key.
+	pub fn user_key(&self) -> &Bytes {
+		&self.user_key
+	}
+
+	/// Returns the version from this field key.
+	pub fn version(&self) -> u64 {
+		self.version
 	}
 }
 
@@ -36,13 +50,22 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	#[case("user", "field", b"\x00\x04user\x00\x00\x00\x05field")]
-	#[case("key", "f", b"\x00\x03key\x00\x00\x00\x01f")]
-	fn test_hash_field_key_encode(#[case] key: &str, #[case] field: &str, #[case] expected: &[u8]) {
+	#[case("user", 1u64, "field")]
+	#[case("key", 0u64, "f")]
+	fn test_hash_field_key_encode(#[case] key: &str, #[case] version: u64, #[case] field: &str) {
 		let field_key = HashFieldKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
+			version,
 			Bytes::copy_from_slice(field.as_bytes()),
 		);
-		assert_eq!(&field_key.encode()[..], expected);
+		let encoded = field_key.encode();
+		// Verify format: key_len(u16) + key + version(u64) + field_len(u32) + field
+		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let version_start = 2 + key.len();
+		assert_eq!(
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
+		);
 	}
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod compaction_filter;
 pub mod data_type;
 pub mod error;
 pub mod expirable;
@@ -11,6 +12,7 @@ pub mod storage_set;
 pub mod storage_string;
 pub mod storage_zset;
 pub mod string;
+pub mod version;
 pub mod zset;
 
 pub use crate::storage::Storage;

--- a/crates/storage/src/list/element_key.rs
+++ b/crates/storage/src/list/element_key.rs
@@ -5,24 +5,38 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct ListElementKey {
 	user_key: Bytes,
+	version: u64,
 	seq: u64,
 }
 
 impl ListElementKey {
-	pub fn new(user_key: impl Into<Bytes>, seq: u64) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, seq: u64) -> Self {
 		Self {
 			user_key: user_key.into(),
+			version,
 			seq,
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + seq (u64 BE)
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8);
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + seq (u64
+		// BE)
+		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 8);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.seq);
 		bytes.freeze()
+	}
+
+	/// Returns the user_key from this element key.
+	pub fn user_key(&self) -> &Bytes {
+		&self.user_key
+	}
+
+	/// Returns the version from this element key.
+	pub fn version(&self) -> u64 {
+		self.version
 	}
 }
 
@@ -33,10 +47,22 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	#[case("mykey", 1, b"\x00\x05mykey\x00\x00\x00\x00\x00\x00\x00\x01")]
-	#[case("key", 255, b"\x00\x03key\x00\x00\x00\x00\x00\x00\x00\xff")]
-	fn test_list_element_key_encode(#[case] key: &str, #[case] seq: u64, #[case] expected: &[u8]) {
-		let element_key = ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), seq);
-		assert_eq!(&element_key.encode()[..], expected);
+	#[case("mykey", 1u64, 100u64)]
+	#[case("key", 0u64, 255u64)]
+	fn test_list_element_key_encode(#[case] key: &str, #[case] version: u64, #[case] seq: u64) {
+		let element_key = ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), version, seq);
+		let encoded = element_key.encode();
+		// Verify format: key_len(u16) + key + version(u64) + seq(u64)
+		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let version_start = 2 + key.len();
+		assert_eq!(
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
+		);
+		assert_eq!(
+			&encoded[version_start + 8..version_start + 16],
+			&seq.to_be_bytes()
+		);
 	}
 }

--- a/crates/storage/src/set/member_key.rs
+++ b/crates/storage/src/set/member_key.rs
@@ -5,27 +5,42 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct SetMemberKey {
 	user_key: Bytes,
+	version: u64,
 	member: Bytes,
 }
 
 impl SetMemberKey {
-	pub fn new(user_key: impl Into<Bytes>, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			version,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + len(member) (u32 BE) + member
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) +
+		// len(member) (u32 BE) + member
 		let member_len = self.member.len() as u32;
 
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 4 + self.member.len());
+		let mut bytes =
+			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.member.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.version);
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
 		bytes.freeze()
+	}
+
+	/// Returns the user_key from this member key.
+	pub fn user_key(&self) -> &Bytes {
+		&self.user_key
+	}
+
+	/// Returns the version from this member key.
+	pub fn version(&self) -> u64 {
+		self.version
 	}
 }
 
@@ -36,17 +51,22 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	#[case("user", "member", b"\x00\x04user\x00\x00\x00\x06member")]
-	#[case("key", "m", b"\x00\x03key\x00\x00\x00\x01m")]
-	fn test_set_member_key_encode(
-		#[case] key: &str,
-		#[case] member: &str,
-		#[case] expected: &[u8],
-	) {
+	#[case("user", 1u64, "member")]
+	#[case("key", 0u64, "m")]
+	fn test_set_member_key_encode(#[case] key: &str, #[case] version: u64, #[case] member: &str) {
 		let member_key = SetMemberKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
+			version,
 			Bytes::copy_from_slice(member.as_bytes()),
 		);
-		assert_eq!(&member_key.encode()[..], expected);
+		let encoded = member_key.encode();
+		// Verify format: key_len(u16) + key + version(u64) + member_len(u32) + member
+		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let version_start = 2 + key.len();
+		assert_eq!(
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
+		);
 	}
 }

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -155,12 +155,6 @@ impl Storage {
 		}
 
 		let meta_val = T::decode(&meta_bytes)?;
-		if meta_val.is_expired() {
-			#[cfg(not(test))]
-			self.del(key.clone()).await?;
-			return Ok(None);
-		}
-
 		Ok(Some(meta_val))
 	}
 }

--- a/crates/storage/src/storage_hash.rs
+++ b/crates/storage/src/storage_hash.rs
@@ -14,20 +14,6 @@ use crate::string::meta::HashMetaValue;
 use crate::string::meta::MetaKey;
 
 impl Storage {
-	// Helper to delete all fields of a hash.
-	// Used when overwriting a Hash with a String, or deleting a Hash.
-	// TODO: This function is temporary; once the compaction filter is implemented,
-	// it will be replaced with a custom filter for elegant deletion.
-	pub(crate) async fn delete_hash_fields(&self, key: Bytes) -> Result<(), StorageError> {
-		// Construct prefix: len(user_key) + user_key
-		let mut prefix = BytesMut::with_capacity(2 + key.len());
-		prefix.put_u16(key.len() as u16);
-		prefix.extend_from_slice(&key);
-		let prefix = prefix.freeze();
-
-		self.delete_keys_by_prefix(&self.hash_db, prefix).await
-	}
-
 	pub async fn hset(&self, key: Bytes, field: Bytes, value: Bytes) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();

--- a/crates/storage/src/storage_hash.rs
+++ b/crates/storage/src/storage_hash.rs
@@ -30,26 +30,20 @@ impl Storage {
 
 	pub async fn hset(&self, key: Bytes, field: Bytes, value: Bytes) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let field_key = HashFieldKey::new(key.clone(), field);
-
-		// Valid type check (Must be Hash or None)
-		// We read from string_db which holds ALL metadata (StringValue or
-		// HashMetaValue)
 		let meta_encoded_key = meta_key.encode();
-		let encoded_field_key = field_key.encode();
 
-		// Parallel fetch meta and field
-		let (meta_res, field_res) = tokio::join!(
-			self.get_meta::<HashMetaValue>(&key),
-			self.hash_db.get(encoded_field_key.clone())
-		);
-
-		let mut meta_val = match meta_res? {
+		// Get metadata first to obtain version
+		let mut meta_val = match self.get_meta::<HashMetaValue>(&key).await? {
 			Some(val) => val,
-			None => HashMetaValue::new(0),
+			None => HashMetaValue::new(self.version_generator.next(), 0),
 		};
 
-		let existing_field_raw = field_res?;
+		// Now create field key with the version from metadata
+		let field_key = HashFieldKey::new(key.clone(), meta_val.version, field);
+		let encoded_field_key = field_key.encode();
+
+		// Check if field already exists
+		let existing_field_raw = self.hash_db.get(encoded_field_key.clone()).await?;
 
 		// If meta was missing/expired (len 0), treat as new field even if loose field
 		// existed (zombie/deleted)
@@ -90,12 +84,12 @@ impl Storage {
 	}
 
 	pub async fn hget(&self, key: Bytes, field: Bytes) -> Result<Option<Bytes>, StorageError> {
-		// Check if the hash exists and is valid
-		if self.get_meta::<HashMetaValue>(&key).await?.is_none() {
+		// Check if the hash exists and is valid, get version
+		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(None);
-		}
+		};
 
-		let field_key = HashFieldKey::new(key, field);
+		let field_key = HashFieldKey::new(key, meta_val.version, field);
 		let result = self.hash_db.get(field_key.encode()).await?;
 		Ok(result)
 	}
@@ -113,10 +107,11 @@ impl Storage {
 		key: Bytes,
 		fields: &[Bytes],
 	) -> Result<Vec<Option<Bytes>>, StorageError> {
-		// Check if the hash exists and is valid
-		if self.get_meta::<HashMetaValue>(&key).await?.is_none() {
+		// Check if the hash exists and is valid, get version
+		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(vec![None; fields.len()]);
-		}
+		};
+		let version = meta_val.version;
 
 		// Create a future for each field lookup to enable concurrent execution
 		// These futures will be awaited in parallel using try_join_all below
@@ -125,7 +120,7 @@ impl Storage {
 			.map(|field| {
 				// We don't need to call self.hget() which repeats the check, we can access
 				// hash_db directly
-				let field_key = HashFieldKey::new(key.clone(), field.clone());
+				let field_key = HashFieldKey::new(key.clone(), version, field.clone());
 				// We need to clone the db handle for the closure/future if needed, but
 				// self.hash_db is Arc Actually self.hash_db.get is async.
 				// We can just call self.hash_db.get
@@ -149,15 +144,16 @@ impl Storage {
 	}
 
 	pub async fn hgetall(&self, key: Bytes) -> Result<Vec<(Bytes, Bytes)>, StorageError> {
-		// Check if the hash exists and is valid
-		if self.get_meta::<HashMetaValue>(&key).await?.is_none() {
+		// Check if the hash exists and is valid, get version
+		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(Vec::new());
-		}
+		};
 
-		// Construct prefix: len(user_key) + user_key
-		let mut prefix = BytesMut::with_capacity(2 + key.len());
+		// Construct prefix: len(user_key) + user_key + version
+		let mut prefix = BytesMut::with_capacity(2 + key.len() + 8);
 		prefix.put_u16(key.len() as u16);
 		prefix.extend_from_slice(&key);
+		prefix.put_u64(meta_val.version);
 		let prefix = prefix.freeze();
 
 		let range = prefix.clone()..;
@@ -172,7 +168,7 @@ impl Storage {
 				break;
 			}
 
-			// Parse field: prefix + len(u32) + field
+			// Parse field: prefix (key_len+key+version) + field_len(u32) + field
 			let suffix = &k[prefix.len()..];
 			if suffix.len() < 4 {
 				continue;
@@ -207,7 +203,7 @@ impl Storage {
 		};
 
 		for field in fields {
-			let field_key = HashFieldKey::new(key.clone(), field.clone());
+			let field_key = HashFieldKey::new(key.clone(), meta_val.version, field.clone());
 			let encoded_field_key = field_key.encode();
 
 			// check if field exists

--- a/crates/storage/src/storage_list.rs
+++ b/crates/storage/src/storage_list.rs
@@ -12,28 +12,6 @@ use crate::string::meta::ListMetaValue;
 use crate::string::meta::MetaKey;
 
 impl Storage {
-	// Helper to delete all elements of a list.
-	pub(crate) async fn delete_list_elements(
-		&self,
-		key: Bytes,
-		meta: &ListMetaValue,
-	) -> Result<(), StorageError> {
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
-		// Elements are stored in the range [head, tail).
-		// head points to the first element, and tail points to one past the last
-		// element. We iterate through this range to delete all individual elements.
-
-		for i in meta.head..meta.tail {
-			let field_key = ListElementKey::new(key.clone(), meta.version, i);
-			self.list_db
-				.delete_with_options(field_key.encode(), &write_opts)
-				.await?;
-		}
-		Ok(())
-	}
-
 	pub async fn lpush(&self, key: Bytes, elements: Vec<Bytes>) -> Result<u64, StorageError> {
 		self.list_push(key, elements, true).await
 	}

--- a/crates/storage/src/storage_set.rs
+++ b/crates/storage/src/storage_set.rs
@@ -13,16 +13,6 @@ use crate::string::meta::MetaKey;
 use crate::string::meta::SetMetaValue;
 
 impl Storage {
-	pub(crate) async fn delete_set_members(&self, key: Bytes) -> Result<(), StorageError> {
-		// Construct prefix: len(user_key) + user_key
-		let mut prefix = BytesMut::with_capacity(2 + key.len());
-		prefix.put_u16(key.len() as u16);
-		prefix.extend_from_slice(&key);
-		let prefix = prefix.freeze();
-
-		self.delete_keys_by_prefix(&self.set_db, prefix).await
-	}
-
 	pub async fn sadd(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();

--- a/crates/storage/src/storage_string.rs
+++ b/crates/storage/src/storage_string.rs
@@ -23,10 +23,6 @@ impl Storage {
 		let key = StringKey::new(key);
 		let value = StringValue::new(value);
 
-		// Clean up if it's a Hash or List
-		// We don't need to delete the content, just the metadata.
-		// The compaction filter will handle the rest.
-
 		let write_opts = WriteOptions {
 			await_durable: false,
 		};
@@ -46,17 +42,15 @@ impl Storage {
 			return Ok(false);
 		}
 
-		// Clean up fields if this is a collection type
-		// We don't need to delete the content, just the metadata.
-		// The compaction filter will handle the rest.
-
 		// Delete from string_db
 		let write_opts = WriteOptions {
 			await_durable: false,
 		};
+
 		self.string_db
 			.delete_with_options(key.encode(), &write_opts)
 			.await?;
+
 		Ok(true)
 	}
 

--- a/crates/storage/src/storage_string.rs
+++ b/crates/storage/src/storage_string.rs
@@ -8,7 +8,6 @@ use crate::expirable::Expirable;
 use crate::storage::Storage;
 use crate::string::key::StringKey;
 use crate::string::meta::AnyValue;
-use crate::string::meta::ListMetaValue;
 use crate::string::value::StringValue;
 
 impl Storage {
@@ -21,31 +20,12 @@ impl Storage {
 	}
 
 	pub async fn set(&self, key: Bytes, value: Bytes) -> Result<(), StorageError> {
-		let user_key = key.clone();
 		let key = StringKey::new(key);
 		let value = StringValue::new(value);
 
-		let meta = self.string_db.get(key.encode()).await?;
-
 		// Clean up if it's a Hash or List
-		if let Some(meta) = meta {
-			match meta.first().and_then(|&b| DataType::from_u8(b)) {
-				Some(DataType::Hash) => {
-					self.delete_hash_fields(user_key).await?;
-				}
-				Some(DataType::List) => {
-					let meta_val = ListMetaValue::decode(&meta)?;
-					self.delete_list_elements(user_key, &meta_val).await?;
-				}
-				Some(DataType::Set) => {
-					self.delete_set_members(user_key).await?;
-				}
-				Some(DataType::ZSet) => {
-					self.delete_zset_content(user_key).await?;
-				}
-				_ => {}
-			}
-		}
+		// We don't need to delete the content, just the metadata.
+		// The compaction filter will handle the rest.
 
 		let write_opts = WriteOptions {
 			await_durable: false,
@@ -58,32 +38,17 @@ impl Storage {
 	}
 
 	pub async fn del(&self, key: Bytes) -> Result<bool, StorageError> {
-		let user_key = key.clone();
 		let key = StringKey::new(key);
 
-		let Some(meta) = self.string_db.get(key.encode()).await? else {
+		// We need to check existence to return correct number of deleted keys (0 or 1).
+		// Even if we don't use the meta value, we need to know if it exists.
+		if self.string_db.get(key.encode()).await?.is_none() {
 			return Ok(false);
-		};
+		}
 
 		// Clean up fields if this is a collection type
-		if let Some(dt) = meta.first().and_then(|&b| DataType::from_u8(b)) {
-			match dt {
-				DataType::Hash => {
-					self.delete_hash_fields(user_key).await?;
-				}
-				DataType::List => {
-					let meta_val = ListMetaValue::decode(&meta)?;
-					self.delete_list_elements(user_key, &meta_val).await?;
-				}
-				DataType::Set => {
-					self.delete_set_members(user_key).await?;
-				}
-				DataType::ZSet => {
-					self.delete_zset_content(user_key).await?;
-				}
-				_ => {}
-			}
-		}
+		// We don't need to delete the content, just the metadata.
+		// The compaction filter will handle the rest.
 
 		// Delete from string_db
 		let write_opts = WriteOptions {

--- a/crates/storage/src/storage_zset.rs
+++ b/crates/storage/src/storage_zset.rs
@@ -170,7 +170,7 @@ impl Storage {
 			let mut result = Vec::new();
 			let mut current_idx = 0;
 			// Cache header length and offset to avoid repeated calculation
-			// prefix = key_len(2) + key + 'S'(1) + version(8), then score(8) + member
+			// prefix = key_len(2) + key + version(8) + b'S'(1), then score(8) + member
 			let header_len = prefix.len() + 8; // prefix + score(8)
 			let score_offset = prefix.len(); // score starts right after prefix
 

--- a/crates/storage/src/string/meta.rs
+++ b/crates/storage/src/string/meta.rs
@@ -64,32 +64,39 @@ impl MetaKey {
 
 #[derive(Debug, PartialEq)]
 pub struct HashMetaValue {
+	pub version: u64,
 	pub len: u64,
 	pub expire_time: u64,
 }
 
 impl HashMetaValue {
-	pub fn new(len: u64) -> Self {
+	pub fn new(version: u64, len: u64) -> Self {
 		Self {
+			version,
 			len,
 			expire_time: 0,
 		}
 	}
 
-	pub fn new_with_ttl(len: u64, expire_time: u64) -> Self {
-		Self { len, expire_time }
+	pub fn new_with_ttl(version: u64, len: u64, expire_time: u64) -> Self {
+		Self {
+			version,
+			len,
+			expire_time,
+		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut bytes = BytesMut::with_capacity(1 + 8 + 8);
+		let mut bytes = BytesMut::with_capacity(1 + 8 + 8 + 8);
 		bytes.put_u8(DataType::Hash as u8);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.len);
 		bytes.put_u64(self.expire_time);
 		bytes.freeze()
 	}
 
 	pub fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
-		if bytes.len() < 17 {
+		if bytes.len() < 25 {
 			return Err(DecoderError::InvalidLength);
 		}
 
@@ -98,9 +105,10 @@ impl HashMetaValue {
 		if type_code != DataType::Hash as u8 {
 			return Err(DecoderError::InvalidType);
 		}
+		let version = buf.get_u64();
 		let len = buf.get_u64();
 		let expire_time = buf.get_u64();
-		Ok(Self::new_with_ttl(len, expire_time))
+		Ok(Self::new_with_ttl(version, len, expire_time))
 	}
 }
 
@@ -134,6 +142,7 @@ impl MetaValue for HashMetaValue {
 
 #[derive(Debug, PartialEq)]
 pub struct ListMetaValue {
+	pub version: u64,
 	pub len: u64,
 	pub head: u64,
 	pub tail: u64,
@@ -141,11 +150,12 @@ pub struct ListMetaValue {
 }
 
 impl ListMetaValue {
-	pub fn new() -> Self {
+	pub fn new(version: u64) -> Self {
 		// Initialize head and tail at the middle of u64 range to allow expansion in
 		// both directions
 		let mid = u64::MAX / 2;
 		Self {
+			version,
 			len: 0,
 			head: mid,
 			tail: mid,
@@ -154,8 +164,9 @@ impl ListMetaValue {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut bytes = BytesMut::with_capacity(1 + 8 + 8 + 8 + 8);
+		let mut bytes = BytesMut::with_capacity(1 + 8 + 8 + 8 + 8 + 8);
 		bytes.put_u8(DataType::List as u8);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.len);
 		bytes.put_u64(self.head);
 		bytes.put_u64(self.tail);
@@ -164,7 +175,7 @@ impl ListMetaValue {
 	}
 
 	pub fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
-		if bytes.len() < 33 {
+		if bytes.len() < 41 {
 			return Err(DecoderError::InvalidLength);
 		}
 
@@ -173,11 +184,13 @@ impl ListMetaValue {
 		if type_code != DataType::List as u8 {
 			return Err(DecoderError::InvalidType);
 		}
+		let version = buf.get_u64();
 		let len = buf.get_u64();
 		let head = buf.get_u64();
 		let tail = buf.get_u64();
 		let expire_time = buf.get_u64();
 		Ok(Self {
+			version,
 			len,
 			head,
 			tail,
@@ -188,7 +201,7 @@ impl ListMetaValue {
 
 impl Default for ListMetaValue {
 	fn default() -> Self {
-		Self::new()
+		Self::new(0)
 	}
 }
 
@@ -222,32 +235,39 @@ impl MetaValue for ListMetaValue {
 
 #[derive(Debug, PartialEq)]
 pub struct SetMetaValue {
+	pub version: u64,
 	pub len: u64,
 	pub expire_time: u64,
 }
 
 impl SetMetaValue {
-	pub fn new(len: u64) -> Self {
+	pub fn new(version: u64, len: u64) -> Self {
 		Self {
+			version,
 			len,
 			expire_time: 0,
 		}
 	}
 
-	pub fn new_with_ttl(len: u64, expire_time: u64) -> Self {
-		Self { len, expire_time }
+	pub fn new_with_ttl(version: u64, len: u64, expire_time: u64) -> Self {
+		Self {
+			version,
+			len,
+			expire_time,
+		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut bytes = BytesMut::with_capacity(1 + 8 + 8);
+		let mut bytes = BytesMut::with_capacity(1 + 8 + 8 + 8);
 		bytes.put_u8(DataType::Set as u8);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.len);
 		bytes.put_u64(self.expire_time);
 		bytes.freeze()
 	}
 
 	pub fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
-		if bytes.len() < 17 {
+		if bytes.len() < 25 {
 			return Err(DecoderError::InvalidLength);
 		}
 
@@ -256,9 +276,10 @@ impl SetMetaValue {
 		if type_code != DataType::Set as u8 {
 			return Err(DecoderError::InvalidType);
 		}
+		let version = buf.get_u64();
 		let len = buf.get_u64();
 		let expire_time = buf.get_u64();
-		Ok(Self::new_with_ttl(len, expire_time))
+		Ok(Self::new_with_ttl(version, len, expire_time))
 	}
 }
 
@@ -292,32 +313,39 @@ impl MetaValue for SetMetaValue {
 
 #[derive(Debug, PartialEq)]
 pub struct ZSetMetaValue {
+	pub version: u64,
 	pub len: u64,
 	pub expire_time: u64,
 }
 
 impl ZSetMetaValue {
-	pub fn new(len: u64) -> Self {
+	pub fn new(version: u64, len: u64) -> Self {
 		Self {
+			version,
 			len,
 			expire_time: 0,
 		}
 	}
 
-	pub fn new_with_ttl(len: u64, expire_time: u64) -> Self {
-		Self { len, expire_time }
+	pub fn new_with_ttl(version: u64, len: u64, expire_time: u64) -> Self {
+		Self {
+			version,
+			len,
+			expire_time,
+		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut bytes = BytesMut::with_capacity(1 + 8 + 8);
+		let mut bytes = BytesMut::with_capacity(1 + 8 + 8 + 8);
 		bytes.put_u8(DataType::ZSet as u8);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.len);
 		bytes.put_u64(self.expire_time);
 		bytes.freeze()
 	}
 
 	pub fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
-		if bytes.len() < 17 {
+		if bytes.len() < 25 {
 			return Err(DecoderError::InvalidLength);
 		}
 
@@ -326,9 +354,10 @@ impl ZSetMetaValue {
 		if type_code != DataType::ZSet as u8 {
 			return Err(DecoderError::InvalidType);
 		}
+		let version = buf.get_u64();
 		let len = buf.get_u64();
 		let expire_time = buf.get_u64();
-		Ok(Self::new_with_ttl(len, expire_time))
+		Ok(Self::new_with_ttl(version, len, expire_time))
 	}
 }
 
@@ -487,17 +516,18 @@ mod tests {
 
 	#[test]
 	fn test_hash_meta_value_encode() {
-		let val = HashMetaValue::new_with_ttl(10, 123456789);
+		let val = HashMetaValue::new_with_ttl(1, 10, 123456789);
 		let encoded = val.encode();
-		assert_eq!(encoded.len(), 17);
+		assert_eq!(encoded.len(), 25);
 		assert_eq!(encoded[0], b'h');
-		assert_eq!(&encoded[1..9], &10u64.to_be_bytes());
-		assert_eq!(&encoded[9..17], &123456789u64.to_be_bytes());
+		assert_eq!(&encoded[1..9], &1u64.to_be_bytes());
+		assert_eq!(&encoded[9..17], &10u64.to_be_bytes());
+		assert_eq!(&encoded[17..25], &123456789u64.to_be_bytes());
 	}
 
 	#[test]
 	fn test_hash_meta_value_decode() {
-		let val = HashMetaValue::new_with_ttl(12345, 987654321);
+		let val = HashMetaValue::new_with_ttl(1, 12345, 987654321);
 		let encoded = val.encode();
 		let decoded = HashMetaValue::decode(&encoded).unwrap();
 		assert_eq!(decoded, val);
@@ -505,7 +535,8 @@ mod tests {
 
 	#[test]
 	fn test_hash_meta_value_new() {
-		let val = HashMetaValue::new(100);
+		let val = HashMetaValue::new(1, 100);
+		assert_eq!(val.version, 1);
 		assert_eq!(val.len, 100);
 		assert_eq!(val.expire_time, 0);
 
@@ -517,17 +548,18 @@ mod tests {
 
 	#[test]
 	fn test_set_meta_value_encode() {
-		let val = SetMetaValue::new_with_ttl(5, 111222333);
+		let val = SetMetaValue::new_with_ttl(1, 5, 111222333);
 		let encoded = val.encode();
-		assert_eq!(encoded.len(), 17);
+		assert_eq!(encoded.len(), 25);
 		assert_eq!(encoded[0], b'S');
-		assert_eq!(&encoded[1..9], &5u64.to_be_bytes());
-		assert_eq!(&encoded[9..17], &111222333u64.to_be_bytes());
+		assert_eq!(&encoded[1..9], &1u64.to_be_bytes());
+		assert_eq!(&encoded[9..17], &5u64.to_be_bytes());
+		assert_eq!(&encoded[17..25], &111222333u64.to_be_bytes());
 	}
 
 	#[test]
 	fn test_set_meta_value_decode() {
-		let val = SetMetaValue::new_with_ttl(555, 999888);
+		let val = SetMetaValue::new_with_ttl(1, 555, 999888);
 		let encoded = val.encode();
 		let decoded = SetMetaValue::decode(&encoded).unwrap();
 		assert_eq!(decoded, val);
@@ -535,7 +567,8 @@ mod tests {
 
 	#[test]
 	fn test_set_meta_value_new() {
-		let val = SetMetaValue::new(50);
+		let val = SetMetaValue::new(1, 50);
+		assert_eq!(val.version, 1);
 		assert_eq!(val.len, 50);
 		assert_eq!(val.expire_time, 0);
 
@@ -546,7 +579,7 @@ mod tests {
 
 	#[test]
 	fn test_list_meta_value_encode_decode() {
-		let mut val = ListMetaValue::new();
+		let mut val = ListMetaValue::new(1);
 		val.len = 5;
 		val.head = 100;
 		val.tail = 105;
@@ -559,7 +592,8 @@ mod tests {
 
 	#[test]
 	fn test_list_meta_value_new() {
-		let val = ListMetaValue::new();
+		let val = ListMetaValue::new(1);
+		assert_eq!(val.version, 1);
 		assert_eq!(val.len, 0);
 		// Approx checking mid range
 		assert!(val.head > 0);
@@ -568,17 +602,18 @@ mod tests {
 
 	#[test]
 	fn test_zset_meta_value_encode() {
-		let val = ZSetMetaValue::new_with_ttl(5, 111222333);
+		let val = ZSetMetaValue::new_with_ttl(1, 5, 111222333);
 		let encoded = val.encode();
-		assert_eq!(encoded.len(), 17);
+		assert_eq!(encoded.len(), 25);
 		assert_eq!(encoded[0], b'z');
-		assert_eq!(&encoded[1..9], &5u64.to_be_bytes());
-		assert_eq!(&encoded[9..17], &111222333u64.to_be_bytes());
+		assert_eq!(&encoded[1..9], &1u64.to_be_bytes());
+		assert_eq!(&encoded[9..17], &5u64.to_be_bytes());
+		assert_eq!(&encoded[17..25], &111222333u64.to_be_bytes());
 	}
 
 	#[test]
 	fn test_zset_meta_value_decode() {
-		let val = ZSetMetaValue::new_with_ttl(555, 999888);
+		let val = ZSetMetaValue::new_with_ttl(1, 555, 999888);
 		let encoded = val.encode();
 		let decoded = ZSetMetaValue::decode(&encoded).unwrap();
 		assert_eq!(decoded, val);

--- a/crates/storage/src/string/meta.rs
+++ b/crates/storage/src/string/meta.rs
@@ -432,6 +432,16 @@ impl AnyValue {
 			Self::ZSet(v) => v.encode(),
 		}
 	}
+
+	pub fn version(&self) -> Option<u64> {
+		match self {
+			Self::String(_) => None,
+			Self::Hash(v) => Some(v.version),
+			Self::List(v) => Some(v.version),
+			Self::Set(v) => Some(v.version),
+			Self::ZSet(v) => Some(v.version),
+		}
+	}
 }
 
 impl Expirable for AnyValue {

--- a/crates/storage/src/string/meta.rs
+++ b/crates/storage/src/string/meta.rs
@@ -199,12 +199,6 @@ impl ListMetaValue {
 	}
 }
 
-impl Default for ListMetaValue {
-	fn default() -> Self {
-		Self::new(0)
-	}
-}
-
 impl Expirable for ListMetaValue {
 	fn expire_time(&self) -> u64 {
 		self.expire_time

--- a/crates/storage/src/version.rs
+++ b/crates/storage/src/version.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
-/// Generates monotonically increasing versions based on microsecond timestamps.
+/// Generates monotonically increasing versions based on seconds timestamps.
 /// If the current timestamp is not greater than the last generated version,
 /// it increments the last version by 1 to guarantee monotonicity.
 pub struct VersionGenerator {
@@ -18,15 +18,11 @@ impl VersionGenerator {
 	/// Generates a new version that is guaranteed to be greater than any
 	/// previously generated version from this generator.
 	pub fn next(&self) -> u64 {
-		let now_micros = chrono::Utc::now().timestamp_micros() as u64;
+		let now = chrono::Utc::now().timestamp() as u64;
 
 		loop {
 			let last = self.last_version.load(Ordering::Acquire);
-			let next = if now_micros > last {
-				now_micros
-			} else {
-				last + 1
-			};
+			let next = if now > last { now } else { last + 1 };
 
 			if self
 				.last_version

--- a/crates/storage/src/version.rs
+++ b/crates/storage/src/version.rs
@@ -1,0 +1,95 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+/// Generates monotonically increasing versions based on microsecond timestamps.
+/// If the current timestamp is not greater than the last generated version,
+/// it increments the last version by 1 to guarantee monotonicity.
+pub struct VersionGenerator {
+	last_version: AtomicU64,
+}
+
+impl VersionGenerator {
+	pub fn new() -> Self {
+		Self {
+			last_version: AtomicU64::new(0),
+		}
+	}
+
+	/// Generates a new version that is guaranteed to be greater than any
+	/// previously generated version from this generator.
+	pub fn next(&self) -> u64 {
+		let now_micros = chrono::Utc::now().timestamp_micros() as u64;
+
+		loop {
+			let last = self.last_version.load(Ordering::Acquire);
+			let next = if now_micros > last {
+				now_micros
+			} else {
+				last + 1
+			};
+
+			if self
+				.last_version
+				.compare_exchange(last, next, Ordering::Release, Ordering::Relaxed)
+				.is_ok()
+			{
+				return next;
+			}
+			// CAS failed, another thread updated; retry
+		}
+	}
+}
+
+impl Default for VersionGenerator {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_version_monotonicity() {
+		let generator = VersionGenerator::new();
+		let mut prev = 0;
+		for _ in 0..1000 {
+			let v = generator.next();
+			assert!(v > prev, "Version should be strictly increasing");
+			prev = v;
+		}
+	}
+
+	#[test]
+	fn test_version_concurrent() {
+		use std::sync::Arc;
+		use std::thread;
+
+		let generator = Arc::new(VersionGenerator::new());
+		let mut handles = vec![];
+
+		for _ in 0..4 {
+			let g = generator.clone();
+			handles.push(thread::spawn(move || {
+				let mut versions = vec![];
+				for _ in 0..100 {
+					versions.push(g.next());
+				}
+				versions
+			}));
+		}
+
+		let mut all_versions: Vec<u64> = handles
+			.into_iter()
+			.flat_map(|h: std::thread::JoinHandle<Vec<u64>>| h.join().unwrap())
+			.collect();
+
+		let len_before = all_versions.len();
+		all_versions.sort();
+		all_versions.dedup();
+		let len_after = all_versions.len();
+
+		assert_eq!(len_before, len_after, "All versions should be unique");
+	}
+}

--- a/crates/storage/src/zset/member_key.rs
+++ b/crates/storage/src/zset/member_key.rs
@@ -5,30 +5,43 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct MemberKey {
 	user_key: Bytes,
+	version: u64,
 	member: Bytes,
 }
 
 impl MemberKey {
-	pub fn new(user_key: impl Into<Bytes>, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			version,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + b'M' + len(member) (u32 BE) +
-		// member
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + b'M' +
+		// len(member) (u32 BE) + member
 		let user_key_len = self.user_key.len() as u16;
 		let member_len = self.member.len() as u32;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 1 + 4 + self.member.len());
+			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 4 + self.member.len());
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.version);
 		bytes.put_u8(b'M');
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
 		bytes.freeze()
+	}
+
+	/// Returns the user_key from this member key.
+	pub fn user_key(&self) -> &Bytes {
+		&self.user_key
+	}
+
+	/// Returns the version from this member key.
+	pub fn version(&self) -> u64 {
+		self.version
 	}
 }

--- a/docs/storage_implementation.md
+++ b/docs/storage_implementation.md
@@ -20,6 +20,7 @@ pub struct Storage {
     pub(crate) list_db: Arc<Db>,
     pub(crate) set_db: Arc<Db>,
     pub(crate) zset_db: Arc<Db>,
+    pub(crate) version_generator: Arc<VersionGenerator>,
 }
 ```
 
@@ -41,7 +42,7 @@ To handle different data types uniformly, the storage layer uses a few key abstr
   1. Fetching raw bytes from `string_db`.
   2. Performing type-code validation.
   3. Decoding the metadata into type `T`.
-  4. Performing application-level lazy expiration checks (including lazy deletion).
+  Expiration is handled entirely by SlateDB's native TTL mechanism; `get_meta` does not perform application-level expiration checks.
 - **`AnyValue` Enum**: A wrapper enum that implements `MetaValue` and can represent any valid Redis data type stored in Nimbis. This allows core commands like `GET`, `EXPIRE`, and `TTL` to operate without type-specific logic.
 
 ### Prefix-Based Deletion

--- a/docs/storage_version_design.md
+++ b/docs/storage_version_design.md
@@ -1,0 +1,82 @@
+# Storage Version Design
+
+This document describes the logical versioning mechanism implemented in the Nimbis storage layer.
+
+## Core Concept
+
+A **Version** is a **logical timestamp** used for **logical version isolation** and **fast deletion**. It determines data validity through version matching, avoiding the performance overhead of physical deletion for large datasets.
+
+---
+
+## 1. Storage Location
+
+Versions exist in both **Meta Values** and **Data Keys**. Together, they determine data visibility.
+
+### 1.1 Version in Meta Value
+Stored in the `string_db` (metadata database), representing the **currently valid** version for a given key.
+
+- **Format**: `[Type] [Version (8B)] [Len] [Expire] ...`
+- **Role**: It acts as the "source of truth". Any read operation first retrieves the version from metadata and only processes data matching this version.
+
+### 1.2 Version in Data Key
+Stored in the keys of collection databases (e.g., `hash_db`, `set_db`). It represents the version at the time the data record was **created**.
+
+- **Key Format**: `UserKey + Version + Member`
+- **Role**: It tags which logical version an individual data item belongs to.
+
+### 1.3 Validity Rule
+Data is considered valid if and only if:
+```
+DataKey.Version == MetaValue.Version
+```
+If the versions do not match, the data is considered "stale" or a "zombie" and is logically deleted.
+
+---
+
+## 2. Generation Rules
+
+The `VersionGenerator` is responsible for producing globally unique and monotonically increasing version numbers.
+
+1.  **Timestamp-Based**: It primarily uses the current **Unix timestamp (in seconds)**.
+2.  **Monotonicity**: If the current timestamp is less than or equal to the last generated version, it increments the last version by 1.
+3.  **Concurrency Safety**: Uses atomic operations to ensure safety in multi-threaded environments.
+
+---
+
+## 3. Key Scenarios
+
+### 3.1 O(1) Fast Deletion
+When performing a `DEL` operation or when a key expires, Nimbis **does not** need to physically delete every member of a collection one by one.
+
+**Workflow**:
+1.  Read and delete the Meta Key (or update the Version in Meta).
+2.  **Efficiency**: The operation takes O(1) time, regardless of the collection's size.
+
+**Result**:
+The old member data remains physically on disk, but because their version no longer matches the (now non-existent or updated) metadata, all read operations automatically ignore them.
+
+### 3.2 Fast Rebuild & Collision Avoidance
+When a key is deleted and immediately recreated with the same name:
+
+**Example**:
+1.  `DEL myset`: Deletes the old Meta (Version=100).
+2.  `SADD myset m1`: Writes a new Meta (Version=101) and new data `(myset, 101, m1)`.
+
+**Result**:
+New and old records are physically isolated by their versions. Even if the old `(myset, 100, m1)` hasn't been cleaned up yet, it will not conflict with the new data.
+
+### 3.3 Async Cleanup (Compaction Filter)
+Invalid data is asynchronously cleaned up by the `NimbisCompactionFilter` during the background compaction process.
+
+**Logic**:
+1.  The Compaction Filter scans each data item.
+2.  It compares `DataKey.Version` with the corresponding `MetaValue.Version`.
+3.  If they do not match, the disk space is reclaimed.
+
+---
+
+## 4. Key Advantages
+
+1.  **High Performance**: Deletion of complex structures no longer slows down as data volume grows.
+2.  **Low Write Amplification**: Deletion requires minimal disk writes, avoiding massive "tombstone" markers.
+3.  **Resource Optimization**: Cleanup is handled in the background, ensuring low latency for frontend requests.

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -1,0 +1,232 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/marsevilspirit/nimbis/tests/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+)
+
+var _ = Describe("Version Isolation", func() {
+	var rdb *redis.Client
+	var ctx context.Context
+
+	BeforeEach(func() {
+		rdb = util.NewClient()
+		ctx = context.Background()
+		Expect(rdb.Ping(ctx).Err()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(rdb.Close()).To(Succeed())
+	})
+
+	// Test that after DEL + re-create, old data is invisible (version isolation)
+	Describe("Set version isolation", func() {
+		It("should not leak old members after DEL and re-create", func() {
+			key := "version_set_test"
+			rdb.Del(ctx, key)
+
+			// 1. Create a set with members
+			n, err := rdb.SAdd(ctx, key, "old_m1", "old_m2", "old_m3").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(3)))
+
+			// 2. DEL the set (logical delete, O(1))
+			deleted, err := rdb.Del(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			// 3. Verify set is gone
+			exists, err := rdb.Exists(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(Equal(int64(0)))
+
+			// 4. Re-create set with new members
+			n, err = rdb.SAdd(ctx, key, "new_m1", "new_m2").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+
+			// 5. Verify ONLY new members are visible (no old data leaking)
+			members, err := rdb.SMembers(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			sort.Strings(members)
+			Expect(members).To(Equal([]string{"new_m1", "new_m2"}))
+
+			// 6. SCARD should be 2, not 5
+			card, err := rdb.SCard(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(card).To(Equal(int64(2)))
+
+			// Cleanup
+			rdb.Del(ctx, key)
+		})
+	})
+
+	Describe("Hash version isolation", func() {
+		It("should not leak old fields after DEL and re-create", func() {
+			key := "version_hash_test"
+			rdb.Del(ctx, key)
+
+			// 1. Create a hash with fields
+			err := rdb.HSet(ctx, key, "old_f1", "v1", "old_f2", "v2").Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			// 2. DEL the hash
+			deleted, err := rdb.Del(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			// 3. Re-create hash
+			err = rdb.HSet(ctx, key, "new_f1", "v3").Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			// 4. Verify ONLY new fields are visible
+			fields, err := rdb.HGetAll(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fields).To(Equal(map[string]string{"new_f1": "v3"}))
+
+			// 5. HLEN should be 1, not 3
+			hlen, err := rdb.HLen(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hlen).To(Equal(int64(1)))
+
+			// 6. Old fields should return nil
+			val, err := rdb.HGet(ctx, key, "old_f1").Result()
+			Expect(err).To(Equal(redis.Nil))
+			Expect(val).To(BeEmpty())
+
+			// Cleanup
+			rdb.Del(ctx, key)
+		})
+	})
+
+	Describe("ZSet version isolation", func() {
+		It("should not leak old members after DEL and re-create", func() {
+			key := "version_zset_test"
+			rdb.Del(ctx, key)
+
+			// 1. Create a sorted set
+			n, err := rdb.ZAdd(ctx, key,
+				redis.Z{Score: 1.0, Member: "old_z1"},
+				redis.Z{Score: 2.0, Member: "old_z2"},
+			).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+
+			// 2. DEL the zset
+			deleted, err := rdb.Del(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			// 3. Re-create zset
+			n, err = rdb.ZAdd(ctx, key,
+				redis.Z{Score: 10.0, Member: "new_z1"},
+			).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			// 4. Verify ONLY new members
+			members, err := rdb.ZRangeWithScores(ctx, key, 0, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(members).To(HaveLen(1))
+			Expect(members[0].Member).To(Equal("new_z1"))
+			Expect(members[0].Score).To(Equal(10.0))
+
+			// 5. ZCARD should be 1, not 3
+			card, err := rdb.ZCard(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(card).To(Equal(int64(1)))
+
+			// Cleanup
+			rdb.Del(ctx, key)
+		})
+	})
+
+	Describe("List version isolation", func() {
+		It("should not leak old elements after DEL and re-create", func() {
+			key := "version_list_test"
+			rdb.Del(ctx, key)
+
+			// 1. Create a list
+			n, err := rdb.RPush(ctx, key, "old_e1", "old_e2", "old_e3").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(3)))
+
+			// 2. DEL the list
+			deleted, err := rdb.Del(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			// 3. Re-create list
+			n, err = rdb.RPush(ctx, key, "new_e1").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			// 4. Verify ONLY new elements
+			elems, err := rdb.LRange(ctx, key, 0, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elems).To(Equal([]string{"new_e1"}))
+
+			// 5. LLEN should be 1, not 4
+			llen, err := rdb.LLen(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(llen).To(Equal(int64(1)))
+
+			// Cleanup
+			rdb.Del(ctx, key)
+		})
+	})
+
+	// Stress test: rapid create-delete cycles should not accumulate visible data
+	Describe("Rapid create-delete cycles", func() {
+		It("should not accumulate stale data across many cycles", func() {
+			key := "version_stress_test"
+			rdb.Del(ctx, key)
+
+			// Perform 20 create-delete cycles
+			for i := 0; i < 20; i++ {
+				// SADD
+				members := []interface{}{
+					fmt.Sprintf("m_%d_a", i),
+					fmt.Sprintf("m_%d_b", i),
+					fmt.Sprintf("m_%d_c", i),
+				}
+				n, err := rdb.SAdd(ctx, key, members...).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(n).To(Equal(int64(3)))
+
+				// DEL
+				deleted, err := rdb.Del(ctx, key).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleted).To(Equal(int64(1)))
+			}
+
+			// After all cycles, key should not exist
+			exists, err := rdb.Exists(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(Equal(int64(0)))
+
+			// Final create with known data
+			n, err := rdb.SAdd(ctx, key, "final_member").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			// Verify ONLY the final member is visible
+			members, err := rdb.SMembers(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(members).To(Equal([]string{"final_member"}))
+
+			card, err := rdb.SCard(ctx, key).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(card).To(Equal(int64(1)))
+
+			// Cleanup
+			rdb.Del(ctx, key)
+		})
+	})
+})


### PR DESCRIPTION
…TTL handling

- Add NimbisCompactionFilter to handle TTL expiration and orphaned key cleanup during compaction in SlateDB
- Add VersionGenerator for monotonically increasing versions based on microsecond timestamps
- Update all collection types (Hash, List, Set, ZSet) to use versioned keys for proper deletion of stale entries during compaction
- String values now store expiry in metadata for consistent TTL handling