### PR TITLE
docs: add build info documentation and make justfile recipes flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See [ROADMAP.md](ROADMAP.md) for the detailed development plan and upcoming feat
 - **Configuration Commands**: `CONFIG GET`, `CONFIG SET`
 - **Persistence**: Data is persisted to SlateDB (object storage compatible).
 - **Configuration**: Dynamic configuration updates via `CONFIG SET`.
+- **Observability**: Detailed build and environment information (git hash, branch, rustc version) displayed on startup.
 
 ## Design Philosophy
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -160,3 +160,12 @@ let current = SERVER_CONF.load();
 ```
 
 This allows the server to dynamically change its log level at runtime via the `CONFIG SET log_level debug` command without restarting.
+
+## 5. Build-time Configuration
+
+In addition to runtime configuration, Nimbis uses a `build.rs` script in the `nimbis` crate to capture environment information at compile time. These values are embedded into the binary and cannot be changed without recompilation:
+
+- **Git Info**: `NIMBIS_GIT_HASH`, `NIMBIS_GIT_BRANCH`, `NIMBIS_GIT_DIRTY`
+- **Build Info**: `NIMBIS_BUILD_DATE`, `NIMBIS_RUSTC_VERSION`, `NIMBIS_TARGET`
+
+These are used primarily by the `logo` module to display detailed version information on startup.

--- a/docs/crates_organization.md
+++ b/docs/crates_organization.md
@@ -101,12 +101,16 @@ just e2e-test
 ## Building
 
 ```bash
-# Build all crates
+# Build all crates (debug)
 just build
+
+# Build all crates (release)
+just build release
 ```
 
 ## Running the Server
 
 ```bash
+# Run server (release)
 just run
 ```

--- a/docs/crates_organization.md
+++ b/docs/crates_organization.md
@@ -54,6 +54,8 @@ The main executable, integrating all crates, implementing the command system and
 
 **Key Components**:
 - **Configuration Management** (`src/config.rs`): Global `SERVER_CONF`, `server_config!` macro, and dynamic update logic.
+- **Build-time Setup** (`build.rs`): Captures git and environment metadata for versioning.
+- **Startup Display** (`src/logo.rs`): Displays banner and build information.
 - `Server` struct
 - TCP connection handling
 - **Command System** (`src/cmd/`): Meta, Trait, and concrete command implementations (GET, SET, HSET, etc.)

--- a/docs/go_integration_tests.md
+++ b/docs/go_integration_tests.md
@@ -24,7 +24,7 @@ The Test Suite is responsible for managing the lifecycle of the `nimbis` server 
 ### Binary Discovery
 The test program attempts to find the `nimbis` executable in the following way:
 1.  **Default Build Path**: Automatically finds the project root (by looking upwards for `Cargo.toml`) and looks for the binary in the approximate path `target/release/nimbis`.
-    - *Hint*: Please ensure `just build release` has been executed before running tests.
+    - *Hint*: Please ensure you produce a release binary (e.g., via `just build release` or `just run`) before running tests.
 
 ### Server Startup Process
 1.  `util.StartServer()` starts a subprocess (`os/exec`) to run `nimbis`.

--- a/justfile
+++ b/justfile
@@ -5,8 +5,8 @@ default:
 
 # Build all crates
 [group: 'misc']
-build profile='release':
-    cargo build {{ if profile == 'release' { "--release" } else { "" } }}
+build *args:
+    cargo build {{args}}
 
 # Run unit tests
 [group: 'test']
@@ -59,5 +59,5 @@ clean:
 
 # Run nimbis-server
 [group: 'misc']
-run:
-    cargo run -p nimbis
+run *args:
+    cargo run -p nimbis {{args}}

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ test:
 
 # Run e2e tests
 [group: 'test']
-e2e-test: build
+e2e-test: (build "--release")
     rm -rf nimbis_data
     cd tests && go test -timeout 15m --ginkgo.v
 


### PR DESCRIPTION
- Add observability feature to README (build info displayed on startup)
- Document build-time configuration (build.rs, env variables) in config.md
- Document new nimbis crate components (build.rs, logo.rs) in crates_organization.md
- Update server_design.md with build info section and startup banner details
- Make justfile build/run recipes accept arbitrary arguments for flexibility