### PR TITLE
chore(deps): bump SlateDB to 0.11.1 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,8 +2647,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?rev=b1e9e7a63b2bd174b3b43b79681640ce9c4baec4#b1e9e7a63b2bd174b3b43b79681640ce9c4baec4"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33982c2d4f2f66fddb6e4bd050c6fcc415944221c0c2775a407b5af0af3388"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,8 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?rev=b1e9e7a63b2bd174b3b43b79681640ce9c4baec4#b1e9e7a63b2bd174b3b43b79681640ce9c4baec4"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f25d1e125ea2f5dcf315e7cc40bc4adce655b382d2350ec37b66d7e97802ff"
 dependencies = [
  "chrono",
  "tokio",
@@ -2702,8 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?rev=b1e9e7a63b2bd174b3b43b79681640ce9c4baec4#b1e9e7a63b2bd174b3b43b79681640ce9c4baec4"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5f20e6b8c7d01cb6a4050a495d3a2e8c435bc8ce439c9b0b72fa2d3096bed8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,7 @@ quote = "1.0.44"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 serde_yaml = "0.9.34"
-slatedb = { git = "https://github.com/slatedb/slatedb.git", rev = "b1e9e7a63b2bd174b3b43b79681640ce9c4baec4", features = [
-    "foyer",
-    "compaction_filters",
-] }
+slatedb = { version = "0.11.1", features = ["foyer", "compaction_filters"] }
 syn = { version = "2.0.114", features = ["full"] }
 tempfile = "3.26.0"
 thiserror = "2.0.18"

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -63,16 +63,20 @@ impl Storage {
 			let store = object_store.clone();
 			let cache = cache.clone();
 			async move {
-				Db::builder(slatedb::object_store::path::Path::from(name), store)
-					.with_memory_cache(cache)
+				let path = slatedb::object_store::path::Path::from(name);
+				let compactor = slatedb::CompactorBuilder::new(path.clone(), store.clone())
 					.with_compaction_filter_supplier(Arc::new(
 						crate::compaction_filter::NimbisCompactionFilterSupplier {
 							string_db,
 							data_type,
 						},
-					))
+					));
+				let db: Result<Db, slatedb::Error> = Db::builder(path, store)
+					.with_db_cache(cache)
+					.with_compactor_builder(compactor)
 					.build()
-					.await
+					.await;
+				db.map_err(StorageError::from)
 			}
 		};
 

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -63,17 +63,18 @@ impl Storage {
 			let store = object_store.clone();
 			let cache = cache.clone();
 			async move {
-				let path = slatedb::object_store::path::Path::from(name);
-				let compactor = slatedb::CompactorBuilder::new(path.clone(), store.clone())
-					.with_compaction_filter_supplier(Arc::new(
-						crate::compaction_filter::NimbisCompactionFilterSupplier {
-							string_db,
-							data_type,
-						},
-					));
-				let db: Result<Db, slatedb::Error> = Db::builder(path, store)
+				let db_path = slatedb::object_store::path::Path::from(name);
+				let compactor_builder =
+					slatedb::CompactorBuilder::new(db_path.clone(), store.clone())
+						.with_compaction_filter_supplier(Arc::new(
+							crate::compaction_filter::NimbisCompactionFilterSupplier {
+								string_db,
+								data_type,
+							},
+						));
+				let db: Result<Db, slatedb::Error> = Db::builder(db_path, store)
 					.with_db_cache(cache)
-					.with_compactor_builder(compactor)
+					.with_compactor_builder(compactor_builder)
 					.build()
 					.await;
 				db.map_err(StorageError::from)

--- a/crates/storage/src/storage_zset.rs
+++ b/crates/storage/src/storage_zset.rs
@@ -68,6 +68,7 @@ impl Storage {
 
 		// Use WriteBatch to ensure atomicity of all zset operations
 		let mut batch = WriteBatch::new();
+		let mut has_writes = false;
 
 		for (idx, (score, member)) in elements.into_iter().enumerate() {
 			let encoded_member_key = &member_encoded_keys[idx];
@@ -78,6 +79,7 @@ impl Storage {
 				let old_score =
 					ScoreKey::decode_score(u64::from_be_bytes(old_score_bytes[..8].try_into()?));
 				if old_score != score {
+					has_writes = true;
 					// Delete old ScoreKey
 					let old_score_key =
 						ScoreKey::new(key.clone(), meta_val.version, old_score, member.clone());
@@ -97,6 +99,7 @@ impl Storage {
 					);
 				}
 			} else {
+				has_writes = true;
 				// New member
 				added_count += 1;
 
@@ -113,7 +116,10 @@ impl Storage {
 				batch.put_with_options(score_key.encode(), Bytes::new(), &put_opts);
 			}
 		}
-		self.zset_db.write_with_options(batch, &write_opts).await?;
+
+		if has_writes {
+			self.zset_db.write_with_options(batch, &write_opts).await?;
+		}
 
 		if added_count > 0 {
 			meta_val.len += added_count;
@@ -256,10 +262,12 @@ impl Storage {
 
 		// Use WriteBatch to ensure atomicity of all delete operations
 		let mut batch = WriteBatch::new();
+		let mut has_writes = false;
 
 		for (idx, member) in members.into_iter().enumerate() {
 			let encoded_member_key = &member_encoded_keys[idx];
 			if let Some(val) = &old_values[idx] {
+				has_writes = true;
 				// Delete MemberKey
 				batch.delete(encoded_member_key.clone());
 
@@ -273,8 +281,10 @@ impl Storage {
 			}
 		}
 
-		// Execute all delete operations atomically
-		self.zset_db.write_with_options(batch, &write_opts).await?;
+		if has_writes {
+			// Execute all delete operations atomically
+			self.zset_db.write_with_options(batch, &write_opts).await?;
+		}
 
 		if removed_count > 0 {
 			meta_val.len -= removed_count;

--- a/crates/storage/src/storage_zset.rs
+++ b/crates/storage/src/storage_zset.rs
@@ -238,38 +238,27 @@ impl Storage {
 			None => return Ok(0),
 		};
 
-		let mut removed_count = 0;
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
-
-		// Batch pre-fetch all member keys to avoid N individual I/O calls
+		// Fetch all member keys in parallel
 		let mut member_encoded_keys = Vec::with_capacity(members.len());
-		for member in &members {
+		let fetch_futures = members.iter().map(|member| {
 			let member_key = MemberKey::new(key.clone(), meta_val.version, member.clone());
-			member_encoded_keys.push(member_key.encode());
-		}
+			let encoded_key = member_key.encode();
+			member_encoded_keys.push(encoded_key.clone());
+			self.zset_db.get(encoded_key)
+		});
 
-		let mut batch_fetches = Vec::new();
-		for encoded_key in &member_encoded_keys {
-			batch_fetches.push(self.zset_db.get(encoded_key.clone()));
-		}
-
-		let mut old_values = Vec::new();
-		for fetch in batch_fetches {
-			old_values.push(fetch.await?);
-		}
+		let old_values: Result<Vec<_>, _> =
+			future::join_all(fetch_futures).await.into_iter().collect();
+		let old_values = old_values?;
 
 		// Use WriteBatch to ensure atomicity of all delete operations
 		let mut batch = WriteBatch::new();
-		let mut has_writes = false;
+		let mut removed_count = 0;
 
 		for (idx, member) in members.into_iter().enumerate() {
-			let encoded_member_key = &member_encoded_keys[idx];
 			if let Some(val) = &old_values[idx] {
-				has_writes = true;
 				// Delete MemberKey
-				batch.delete(encoded_member_key.clone());
+				batch.delete(&member_encoded_keys[idx]);
 
 				// Delete ScoreKey
 				let encoded_score = u64::from_be_bytes(val[..8].try_into()?);
@@ -281,29 +270,33 @@ impl Storage {
 			}
 		}
 
-		if has_writes {
-			// Execute all delete operations atomically
-			self.zset_db.write_with_options(batch, &write_opts).await?;
+		if removed_count == 0 {
+			return Ok(0);
 		}
 
-		if removed_count > 0 {
-			meta_val.len -= removed_count;
-			if meta_val.len == 0 {
-				self.string_db
-					.delete_with_options(meta_encoded_key, &write_opts)
-					.await?;
-			} else {
-				let ttl = meta_val
-					.remaining_ttl()
-					.map(|d| d.as_millis() as u64)
-					.map(slatedb::config::Ttl::ExpireAfter)
-					.unwrap_or(slatedb::config::Ttl::NoExpiry);
+		let write_opts = WriteOptions {
+			await_durable: false,
+		};
 
-				let put_opts = PutOptions { ttl };
-				self.string_db
-					.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-					.await?;
-			}
+		// Execute all delete operations atomically
+		self.zset_db.write_with_options(batch, &write_opts).await?;
+
+		meta_val.len -= removed_count;
+		if meta_val.len == 0 {
+			self.string_db
+				.delete_with_options(meta_encoded_key, &write_opts)
+				.await?;
+		} else {
+			let ttl = meta_val
+				.remaining_ttl()
+				.map(|d| d.as_millis() as u64)
+				.map(slatedb::config::Ttl::ExpireAfter)
+				.unwrap_or(slatedb::config::Ttl::NoExpiry);
+
+			let put_opts = PutOptions { ttl };
+			self.string_db
+				.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
+				.await?;
 		}
 
 		Ok(removed_count)


### PR DESCRIPTION
- Upgrade SlateDB dependency from git revision to crates.io version
- Update API usage: with_memory_cache -> with_db_cache, add CompactorBuilder
- Optimize ZSet operations to skip empty WriteBatch writes