### PR TITLE
style: apply clippy suggestions

### DIFF
--- a/crates/resp/examples/parse_stream.rs
+++ b/crates/resp/examples/parse_stream.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_macros)]
+
 use bytes::BytesMut;
 use resp::RespParseResult;
 use resp::RespParser;
@@ -11,7 +13,7 @@ fn main() {
 	// - An Integer: ":1000\r\n"
 	// - An Array: "*2\r\n$3\r\nSET\r\n$3\r\nkey\r\n"
 	// - But split into random chunks.
-	let data_chunks = vec![
+	let data_chunks = [
 		b"+O".as_slice(),
 		b"K\r\n:1".as_slice(),
 		b"00".as_slice(),

--- a/crates/resp/src/encode.rs
+++ b/crates/resp/src/encode.rs
@@ -272,7 +272,7 @@ mod tests {
 	}
 
 	#[rstest]
-	#[case(3.14, b",3.14\r\n")]
+	#[case(std::f64::consts::PI, b",3.141592653589793\r\n")]
 	#[case(10.0, b",10\r\n")]
 	#[case(f64::INFINITY, b",inf\r\n")]
 	#[case(f64::NEG_INFINITY, b",-inf\r\n")]

--- a/crates/resp/src/parser.rs
+++ b/crates/resp/src/parser.rs
@@ -719,7 +719,7 @@ mod tests {
 	fn test_parse_inline_command_too_long() {
 		// 64KB + 1 byte
 		let mut big_cmd = Vec::new();
-		big_cmd.extend(std::iter::repeat(b'a').take(65537));
+		big_cmd.extend(std::iter::repeat_n(b'a', 65537));
 		big_cmd.extend_from_slice(b"\r\n");
 		let mut buf = BytesMut::from(&big_cmd[..]);
 

--- a/crates/resp/src/utils.rs
+++ b/crates/resp/src/utils.rs
@@ -164,7 +164,7 @@ mod tests {
 	}
 
 	#[rstest]
-	#[case(b"3.14", 3.14)]
+	#[case(b"3.141592653589793", std::f64::consts::PI)]
 	#[case(b"-2.5", -2.5)]
 	#[case(b"inf", f64::INFINITY)]
 	#[case(b"-inf", f64::NEG_INFINITY)]

--- a/crates/resp/tests/parser_tests.rs
+++ b/crates/resp/tests/parser_tests.rs
@@ -126,9 +126,9 @@ fn test_resp3_types() {
 	assert_eq!(value.as_bool(), Some(false));
 
 	// Double
-	let mut buf = BytesMut::from(&b",3.14159\r\n"[..]);
+	let mut buf = BytesMut::from(&b",3.141592653589793\r\n"[..]);
 	let value = resp::parse(&mut buf).unwrap();
-	assert_eq!(value.as_double(), Some(3.14159));
+	assert_eq!(value.as_double(), Some(std::f64::consts::PI));
 
 	// Null
 	let mut buf = BytesMut::from(&b"_\r\n"[..]);

--- a/crates/storage/src/compaction_filter.rs
+++ b/crates/storage/src/compaction_filter.rs
@@ -366,7 +366,7 @@ mod tests {
 		let members: &[&[u8]] = &[b"alice", b"bob", b"carol"];
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(42, *member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
 				seq: 1,
 				create_ts: None,
@@ -377,7 +377,7 @@ mod tests {
 				filter.filter(&entry).await.unwrap(),
 				CompactionFilterDecision::Keep,
 				"member {:?} should be kept when version matches",
-				std::str::from_utf8(*member).unwrap()
+				std::str::from_utf8(member).unwrap()
 			);
 		}
 
@@ -393,7 +393,7 @@ mod tests {
 		// Now all sub-keys should be marked for deletion (orphaned)
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(42, *member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
 				seq: 1,
 				create_ts: None,
@@ -403,7 +403,7 @@ mod tests {
 				filter.filter(&entry).await.unwrap(),
 				CompactionFilterDecision::Modify(ValueDeletable::Tombstone),
 				"member {:?} should be reclaimed after metadata deletion",
-				std::str::from_utf8(*member).unwrap()
+				std::str::from_utf8(member).unwrap()
 			);
 		}
 
@@ -417,7 +417,7 @@ mod tests {
 		// Old version=42 data should still be reclaimed
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(42, *member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
 				seq: 1,
 				create_ts: None,
@@ -427,7 +427,7 @@ mod tests {
 				filter.filter(&entry).await.unwrap(),
 				CompactionFilterDecision::Modify(ValueDeletable::Tombstone),
 				"old version member {:?} should be reclaimed after re-creation",
-				std::str::from_utf8(*member).unwrap()
+				std::str::from_utf8(member).unwrap()
 			);
 		}
 

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -179,7 +179,7 @@ mod tests {
 
 	#[test]
 	fn test_error_codes_unique() {
-		let codes = vec![
+		let codes = [
 			DecoderError::Empty.code(),
 			DecoderError::InvalidType.code(),
 			DecoderError::InvalidLength.code(),
@@ -246,7 +246,7 @@ mod tests {
 
 	#[test]
 	fn test_storage_error_codes_unique() {
-		let codes = vec!["E1000", "E1001", "E1002", "E1003", "E1004"];
+		let codes = ["E1000", "E1001", "E1002", "E1003", "E1004"];
 		let unique_codes: std::collections::HashSet<_> = codes.iter().collect();
 		assert_eq!(
 			codes.len(),

--- a/crates/storage/src/storage_hash.rs
+++ b/crates/storage/src/storage_hash.rs
@@ -337,7 +337,10 @@ mod tests {
 			.unwrap();
 
 		// HDEL one field
-		let count = storage.hdel(key.clone(), &[f1.clone()]).await.unwrap();
+		let count = storage
+			.hdel(key.clone(), std::slice::from_ref(&f1))
+			.await
+			.unwrap();
 		assert_eq!(count, 1);
 
 		// Verify f1 gone, f2 remains
@@ -356,7 +359,10 @@ mod tests {
 		assert_eq!(count, 0);
 
 		// HDEL remaining field (should delete hash meta)
-		let count = storage.hdel(key.clone(), &[f2.clone()]).await.unwrap();
+		let count = storage
+			.hdel(key.clone(), std::slice::from_ref(&f2))
+			.await
+			.unwrap();
 		assert_eq!(count, 1);
 
 		// Verify empty

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ e2e-test: (build "--release")
 check: check-workspace check-code-fmt check-numbered-comments
     cargo check --workspace
     cargo fmt -- --check
-    cargo clippy --workspace -- -D warnings
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
     rustfmt --check scripts/*.rs
 
 # Check workspace dependencies


### PR DESCRIPTION
- Use array literals instead of vec![] where possible
- Use repeat_n instead of repeat().take()
- Use std::f64::consts::PI for consistent float values
- Pass references directly instead of dereferencing
- Add --all-targets --all-features to clippy check