### PR TITLE
refactor(telemetry): implement custom rolling file appender

### DIFF
--- a/crates/nimbis/src/logo.rs
+++ b/crates/nimbis/src/logo.rs
@@ -7,7 +7,6 @@ pub const LOGO: &str = r#"
 
 const LABEL_WIDTH: usize = 13;
 
-#[allow(clippy::disallowed_macros)]
 pub fn show_logo() {
 	let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
 
@@ -33,5 +32,5 @@ pub fn show_logo() {
 		.collect::<Vec<_>>()
 		.join("\n");
 
-	println!("{}\n{}\n", LOGO.trim_end(), info);
+	log::info!("nimbis version info:\n{}\n{}", LOGO.trim_end(), info);
 }

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -268,12 +268,12 @@ impl Terminal {
 impl File {
 	/// Create a file logger target from a path template.
 	///
-	/// The parent directory is used as the log directory. The file stem becomes
-	/// the rolling appender prefix, and the extension becomes the suffix when
-	/// one is present. With time-based rotation (`minutely`, `hourly`,
-	/// `daily`), the appender writes files under that directory using that
-	/// prefix/suffix pair and adds its rotation timestamp to the on-disk file
-	/// name. With `never`, it keeps writing to the single provided path.
+	/// The parent directory is used as the log directory. The appender always
+	/// writes to the active file at the exact path provided. With time-based
+	/// rotation (`minutely`, `hourly`, `daily`), the active file is archived
+	/// upon rotation. The file stem becomes the prefix, the extension becomes 
+	/// the suffix, and a rotation timestamp is added to the archived file name.
+	/// With `never`, it keeps writing to the single provided path without archiving.
 	pub fn new(path: impl Into<PathBuf>, rotation: LogRotation) -> Self {
 		Self {
 			path: path.into(),
@@ -356,9 +356,10 @@ where
 ///
 /// * `level` - The log level filter string (e.g., "info", "debug", "warn")
 /// * `output` - The output sink to use. When configured for file output with a
-///   path like `./nimbis_store/nimbis.log`, time-based rotation writes files in
-///   `./nimbis_store/` using `nimbis` as the base name and `log` as the suffix;
-///   only `LogRotation::Never` keeps writing to the single `nimbis.log` path.
+///   path like `./nimbis_store/nimbis.log`, it writes to that exact path. On 
+///   time-based rotation, it archives the file in `./nimbis_store/` using `nimbis` 
+///   as the base name, the timestamp, and `log` as the suffix; `LogRotation::Never` 
+///   skips archiving and keeps writing to `nimbis.log`.
 ///
 /// # Example
 ///

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -151,7 +151,10 @@ impl CustomRollingFile {
 			next_rotation_time: None,
 		};
 
-		appender.archive_active_file();
+		if rotation != LogRotation::Never {
+			appender.archive_active_file();
+		}
+
 		appender.open_active_file()?;
 
 		Ok(appender)
@@ -174,7 +177,9 @@ impl CustomRollingFile {
 			}
 			let archive_path = self.directory.join(archive_name);
 
-			let _ = std::fs::rename(&self.active_path, &archive_path);
+			if let Err(e) = std::fs::rename(&self.active_path, &archive_path) {
+				panic!("telemetry: failed to rotate log file: {}", e);
+			}
 		}
 	}
 

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -540,4 +540,136 @@ mod tests {
 			level
 		);
 	}
+
+	// CustomRollingFile tests
+
+	/// Test that creating CustomRollingFile with valid path succeeds
+	#[test]
+	fn test_custom_rolling_file_new_success() {
+		let temp_dir = std::env::temp_dir().join("nimbis_test_new");
+		std::fs::create_dir_all(&temp_dir).ok();
+		let log_path = temp_dir.join("test.log");
+
+		let result = CustomRollingFile::new(&log_path, LogRotation::Never);
+		assert!(result.is_ok());
+
+		// Cleanup
+		std::fs::remove_file(&log_path).ok();
+		std::fs::remove_dir(&temp_dir).ok();
+	}
+
+	/// Test that creating CustomRollingFile with no file stem returns error
+	#[test]
+	fn test_custom_rolling_file_no_stem_error() {
+		// Using a directory path (no file name component) should fail
+		let temp_dir = std::env::temp_dir().join("nimbis_test_no_stem");
+		std::fs::create_dir_all(&temp_dir).ok();
+
+		// This is essentially a directory, not a file path
+		let result = CustomRollingFile::new(&temp_dir, LogRotation::Never);
+		assert!(matches!(result, Err(TelemetryError::InitFailed(_))));
+
+		// Cleanup
+		std::fs::remove_dir(&temp_dir).ok();
+	}
+
+	/// Test that LogRotation::Never skips archiving
+	#[test]
+	fn test_custom_rolling_file_no_archive_on_never() {
+		let temp_dir = std::env::temp_dir().join("nimbis_test_no_archive");
+		std::fs::create_dir_all(&temp_dir).ok();
+		let log_path = temp_dir.join("test.log");
+
+		// Create initial file
+		std::fs::write(&log_path, "initial content").ok();
+
+		let result = CustomRollingFile::new(&log_path, LogRotation::Never);
+		assert!(result.is_ok());
+
+		// File should still exist (not archived)
+		assert!(log_path.exists());
+		let content = std::fs::read_to_string(&log_path).unwrap_or_default();
+		assert!(content.contains("initial content"));
+
+		// Cleanup
+		std::fs::remove_file(&log_path).ok();
+		std::fs::remove_dir(&temp_dir).ok();
+	}
+
+	/// Test that archiving happens when rotation is not Never
+	#[test]
+	fn test_custom_rolling_file_archive_on_rotation() {
+		let temp_dir = std::env::temp_dir().join("nimbis_test_archive");
+		std::fs::create_dir_all(&temp_dir).ok();
+		let log_path = temp_dir.join("test.log");
+
+		// Create initial file with content
+		std::fs::write(&log_path, "old content").ok();
+
+		// Create with hourly rotation - should archive existing file
+		let result = CustomRollingFile::new(&log_path, LogRotation::Hourly);
+		assert!(result.is_ok());
+
+		// Original file should be renamed to archive
+		// The active file should exist (empty or new)
+		assert!(log_path.exists(), "Active file should exist");
+
+		// There should be an archive file in the directory
+		let entries: Vec<_> = std::fs::read_dir(&temp_dir)
+			.unwrap()
+			.filter_map(|e| e.ok())
+			.map(|e| e.file_name().to_string_lossy().to_string())
+			.filter(|n| n.starts_with("test-"))
+			.collect();
+		assert!(
+			!entries.is_empty(),
+			"Archive file should exist with prefix test-"
+		);
+
+		// Cleanup
+		for entry in std::fs::read_dir(&temp_dir).unwrap().filter_map(|e| e.ok()) {
+			std::fs::remove_file(entry.path()).ok();
+		}
+		std::fs::remove_dir(&temp_dir).ok();
+	}
+
+	/// Test writing to CustomRollingFile
+	#[test]
+	fn test_custom_rolling_file_write() {
+		let temp_dir = std::env::temp_dir().join("nimbis_test_write");
+		std::fs::create_dir_all(&temp_dir).ok();
+		let log_path = temp_dir.join("test.log");
+
+		let mut file = CustomRollingFile::new(&log_path, LogRotation::Never).unwrap();
+		let write_result = file.write_all(b"test message\n");
+		assert!(write_result.is_ok());
+
+		let content = std::fs::read_to_string(&log_path).unwrap_or_default();
+		assert!(content.contains("test message"));
+
+		// Cleanup
+		drop(file);
+		std::fs::remove_file(&log_path).ok();
+		std::fs::remove_dir(&temp_dir).ok();
+	}
+
+	/// Test that creating file in non-existent directory creates it
+	#[test]
+	fn test_custom_rolling_file_creates_directory() {
+		let temp_dir = std::env::temp_dir()
+			.join("nimbis_test_nested")
+			.join("subdir");
+		let log_path = temp_dir.join("test.log");
+
+		// Directory should not exist
+		assert!(!temp_dir.exists());
+
+		let result = CustomRollingFile::new(&log_path, LogRotation::Never);
+		assert!(result.is_ok());
+		assert!(temp_dir.exists());
+
+		// Cleanup
+		std::fs::remove_file(&log_path).ok();
+		std::fs::remove_dir_all(temp_dir.parent().unwrap()).ok();
+	}
 }

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -109,27 +109,6 @@ impl LogRotation {
 	}
 }
 
-#[derive(PartialEq, Eq)]
-enum Period {
-	Minutely(i32, u32, u32, u32, u32),
-	Hourly(i32, u32, u32, u32),
-	Daily(i32, u32, u32),
-	Never,
-}
-
-impl Period {
-	fn current(now: DateTime<Local>, rotation: LogRotation) -> Self {
-		match rotation {
-			LogRotation::Minutely => {
-				Self::Minutely(now.year(), now.month(), now.day(), now.hour(), now.minute())
-			}
-			LogRotation::Hourly => Self::Hourly(now.year(), now.month(), now.day(), now.hour()),
-			LogRotation::Daily => Self::Daily(now.year(), now.month(), now.day()),
-			LogRotation::Never => Self::Never,
-		}
-	}
-}
-
 pub struct CustomRollingFile {
 	directory: PathBuf,
 	file_stem: String,
@@ -137,7 +116,7 @@ pub struct CustomRollingFile {
 	rotation: LogRotation,
 	active_path: PathBuf,
 	active_file: Option<StdFile>,
-	active_period: Period,
+	next_rotation_time: Option<std::time::SystemTime>,
 }
 
 impl CustomRollingFile {
@@ -169,7 +148,7 @@ impl CustomRollingFile {
 			rotation,
 			active_path: path.clone(),
 			active_file: None,
-			active_period: Period::Never,
+			next_rotation_time: None,
 		};
 
 		appender.archive_active_file();
@@ -199,6 +178,34 @@ impl CustomRollingFile {
 		}
 	}
 
+	fn calculate_next_rotation(now: DateTime<Local>, rotation: LogRotation) -> Option<std::time::SystemTime> {
+		use chrono::TimeZone;
+		match rotation {
+			LogRotation::Minutely => {
+				let next = now + chrono::Duration::minutes(1);
+				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), next.hour(), next.minute(), 0)
+					.latest()
+					.or_else(|| Some(next))
+					.map(|dt| dt.into())
+			}
+			LogRotation::Hourly => {
+				let next = now + chrono::Duration::hours(1);
+				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), next.hour(), 0, 0)
+					.latest()
+					.or_else(|| Some(next))
+					.map(|dt| dt.into())
+			}
+			LogRotation::Daily => {
+				let next = now + chrono::Duration::days(1);
+				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), 0, 0, 0)
+					.latest()
+					.or_else(|| Some(next))
+					.map(|dt| dt.into())
+			}
+			LogRotation::Never => None,
+		}
+	}
+
 	fn open_active_file(&mut self) -> Result<(), TelemetryError> {
 		let file = OpenOptions::new()
 			.create(true)
@@ -207,16 +214,19 @@ impl CustomRollingFile {
 			.map_err(|e| TelemetryError::InitFailed(e.to_string()))?;
 
 		self.active_file = Some(file);
-		self.active_period = Period::current(Local::now(), self.rotation);
+		self.next_rotation_time = Self::calculate_next_rotation(Local::now(), self.rotation);
 		Ok(())
 	}
 }
 
 impl Write for CustomRollingFile {
 	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-		let current_period = Period::current(Local::now(), self.rotation);
+		let should_rotate = match self.next_rotation_time {
+			Some(time) => std::time::SystemTime::now() >= time,
+			None => false,
+		};
 
-		if current_period != self.active_period && self.rotation != LogRotation::Never {
+		if should_rotate && self.rotation != LogRotation::Never {
 			self.active_file = None;
 			self.archive_active_file();
 			if let Err(e) = self.open_active_file() {

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use chrono::DateTime;
 use chrono::Datelike;
 use chrono::Local;
+use chrono::TimeZone;
 use chrono::Timelike;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::EnvFilter;
@@ -183,28 +184,40 @@ impl CustomRollingFile {
 		}
 	}
 
-	fn calculate_next_rotation(now: DateTime<Local>, rotation: LogRotation) -> Option<std::time::SystemTime> {
-		use chrono::TimeZone;
+	fn calculate_next_rotation(
+		now: DateTime<Local>,
+		rotation: LogRotation,
+	) -> Option<std::time::SystemTime> {
 		match rotation {
 			LogRotation::Minutely => {
 				let next = now + chrono::Duration::minutes(1);
-				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), next.hour(), next.minute(), 0)
+				Local
+					.with_ymd_and_hms(
+						next.year(),
+						next.month(),
+						next.day(),
+						next.hour(),
+						next.minute(),
+						0,
+					)
 					.latest()
-					.or_else(|| Some(next))
+					.or(Some(next))
 					.map(|dt| dt.into())
 			}
 			LogRotation::Hourly => {
 				let next = now + chrono::Duration::hours(1);
-				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), next.hour(), 0, 0)
+				Local
+					.with_ymd_and_hms(next.year(), next.month(), next.day(), next.hour(), 0, 0)
 					.latest()
-					.or_else(|| Some(next))
+					.or(Some(next))
 					.map(|dt| dt.into())
 			}
 			LogRotation::Daily => {
 				let next = now + chrono::Duration::days(1);
-				Local.with_ymd_and_hms(next.year(), next.month(), next.day(), 0, 0, 0)
+				Local
+					.with_ymd_and_hms(next.year(), next.month(), next.day(), 0, 0, 0)
 					.latest()
-					.or_else(|| Some(next))
+					.or(Some(next))
 					.map(|dt| dt.into())
 			}
 			LogRotation::Never => None,
@@ -271,9 +284,10 @@ impl File {
 	/// The parent directory is used as the log directory. The appender always
 	/// writes to the active file at the exact path provided. With time-based
 	/// rotation (`minutely`, `hourly`, `daily`), the active file is archived
-	/// upon rotation. The file stem becomes the prefix, the extension becomes 
+	/// upon rotation. The file stem becomes the prefix, the extension becomes
 	/// the suffix, and a rotation timestamp is added to the archived file name.
-	/// With `never`, it keeps writing to the single provided path without archiving.
+	/// With `never`, it keeps writing to the single provided path without
+	/// archiving.
 	pub fn new(path: impl Into<PathBuf>, rotation: LogRotation) -> Self {
 		Self {
 			path: path.into(),
@@ -356,10 +370,10 @@ where
 ///
 /// * `level` - The log level filter string (e.g., "info", "debug", "warn")
 /// * `output` - The output sink to use. When configured for file output with a
-///   path like `./nimbis_store/nimbis.log`, it writes to that exact path. On 
-///   time-based rotation, it archives the file in `./nimbis_store/` using `nimbis` 
-///   as the base name, the timestamp, and `log` as the suffix; `LogRotation::Never` 
-///   skips archiving and keeps writing to `nimbis.log`.
+///   path like `./nimbis_store/nimbis.log`, it writes to that exact path. On
+///   time-based rotation, it archives the file in `./nimbis_store/` using
+///   `nimbis` as the base name, the timestamp, and `log` as the suffix;
+///   `LogRotation::Never` skips archiving and keeps writing to `nimbis.log`.
 ///
 /// # Example
 ///

--- a/crates/telemetry/src/logger.rs
+++ b/crates/telemetry/src/logger.rs
@@ -1,8 +1,15 @@
+use std::fs::File as StdFile;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::io::{self};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use chrono::DateTime;
+use chrono::Datelike;
+use chrono::Local;
+use chrono::Timelike;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_appender::rolling::Rotation;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 use tracing_subscriber::fmt;
@@ -100,13 +107,135 @@ impl LogRotation {
 			_ => Err(TelemetryError::InvalidLogRotation(mode.to_string())),
 		}
 	}
+}
 
-	fn as_rotation(self) -> Rotation {
-		match self {
-			Self::Minutely => Rotation::MINUTELY,
-			Self::Hourly => Rotation::HOURLY,
-			Self::Daily => Rotation::DAILY,
-			Self::Never => Rotation::NEVER,
+#[derive(PartialEq, Eq)]
+enum Period {
+	Minutely(i32, u32, u32, u32, u32),
+	Hourly(i32, u32, u32, u32),
+	Daily(i32, u32, u32),
+	Never,
+}
+
+impl Period {
+	fn current(now: DateTime<Local>, rotation: LogRotation) -> Self {
+		match rotation {
+			LogRotation::Minutely => {
+				Self::Minutely(now.year(), now.month(), now.day(), now.hour(), now.minute())
+			}
+			LogRotation::Hourly => Self::Hourly(now.year(), now.month(), now.day(), now.hour()),
+			LogRotation::Daily => Self::Daily(now.year(), now.month(), now.day()),
+			LogRotation::Never => Self::Never,
+		}
+	}
+}
+
+pub struct CustomRollingFile {
+	directory: PathBuf,
+	file_stem: String,
+	extension: Option<String>,
+	rotation: LogRotation,
+	active_path: PathBuf,
+	active_file: Option<StdFile>,
+	active_period: Period,
+}
+
+impl CustomRollingFile {
+	pub fn new(path: impl Into<PathBuf>, rotation: LogRotation) -> Result<Self, TelemetryError> {
+		let path = path.into();
+		let directory = path
+			.parent()
+			.unwrap_or(std::path::Path::new(""))
+			.to_path_buf();
+
+		if !directory.exists() && directory.to_string_lossy() != "" {
+			std::fs::create_dir_all(&directory)
+				.map_err(|e| TelemetryError::InitFailed(e.to_string()))?;
+		}
+
+		let file_stem = path
+			.file_stem()
+			.ok_or_else(|| {
+				TelemetryError::InitFailed(format!("log file has no stem: {}", path.display()))
+			})?
+			.to_string_lossy()
+			.into_owned();
+		let extension = path.extension().map(|e| e.to_string_lossy().into_owned());
+
+		let mut appender = Self {
+			directory,
+			file_stem,
+			extension,
+			rotation,
+			active_path: path.clone(),
+			active_file: None,
+			active_period: Period::Never,
+		};
+
+		appender.archive_active_file();
+		appender.open_active_file()?;
+
+		Ok(appender)
+	}
+
+	fn archive_active_file(&mut self) {
+		if self.active_path.exists() {
+			let meta = std::fs::metadata(&self.active_path);
+			let modified_time: DateTime<Local> = meta
+				.and_then(|m| m.modified())
+				.unwrap_or_else(|_| std::time::SystemTime::now())
+				.into();
+
+			let timestamp = modified_time.format("%Y-%m-%d-%H-%M-%3f").to_string();
+
+			let mut archive_name = format!("{}-{}", self.file_stem, timestamp);
+			if let Some(ext) = &self.extension {
+				archive_name.push('.');
+				archive_name.push_str(ext);
+			}
+			let archive_path = self.directory.join(archive_name);
+
+			let _ = std::fs::rename(&self.active_path, &archive_path);
+		}
+	}
+
+	fn open_active_file(&mut self) -> Result<(), TelemetryError> {
+		let file = OpenOptions::new()
+			.create(true)
+			.append(true)
+			.open(&self.active_path)
+			.map_err(|e| TelemetryError::InitFailed(e.to_string()))?;
+
+		self.active_file = Some(file);
+		self.active_period = Period::current(Local::now(), self.rotation);
+		Ok(())
+	}
+}
+
+impl Write for CustomRollingFile {
+	fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+		let current_period = Period::current(Local::now(), self.rotation);
+
+		if current_period != self.active_period && self.rotation != LogRotation::Never {
+			self.active_file = None;
+			self.archive_active_file();
+			if let Err(e) = self.open_active_file() {
+				return Err(io::Error::other(e.to_string()));
+			}
+		}
+
+		if let Some(file) = &mut self.active_file {
+			file.write(buf)
+		} else {
+			Err(io::Error::other("file closed"))
+		}
+	}
+
+	fn flush(&mut self) -> io::Result<()> {
+		if let Some(file) = &mut self.active_file {
+			file.flush()
+		} else {
+			Ok(())
 		}
 	}
 }
@@ -116,7 +245,7 @@ impl Terminal {
 		self,
 		filter_layer: reload::Layer<EnvFilter, Registry>,
 	) -> Result<LoggerGuard, TelemetryError> {
-		init_subscriber(filter_layer, std::io::stderr)?;
+		init_subscriber(filter_layer, std::io::stderr, true)?;
 		Ok(LoggerGuard::terminal())
 	}
 }
@@ -141,32 +270,10 @@ impl File {
 		self,
 		filter_layer: reload::Layer<EnvFilter, Registry>,
 	) -> Result<LoggerGuard, TelemetryError> {
-		let parent = self.path.parent().ok_or_else(|| {
-			TelemetryError::InitFailed(format!(
-				"log file path has no parent directory: {}",
-				self.path.display()
-			))
-		})?;
-		let file_stem = self.path.file_stem().ok_or_else(|| {
-			TelemetryError::InitFailed(format!(
-				"log file path has no file stem: {}",
-				self.path.display()
-			))
-		})?;
-		let mut builder = tracing_appender::rolling::Builder::new()
-			.rotation(self.rotation.as_rotation())
-			.filename_prefix(file_stem.to_string_lossy().into_owned());
-
-		if let Some(extension) = self.path.extension() {
-			builder = builder.filename_suffix(extension.to_string_lossy().into_owned());
-		}
-
-		let file_appender = builder
-			.build(parent)
-			.map_err(|e| TelemetryError::InitFailed(e.to_string()))?;
+		let file_appender = CustomRollingFile::new(self.path.clone(), self.rotation)?;
 		let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-		init_subscriber(filter_layer, non_blocking)?;
+		init_subscriber(filter_layer, non_blocking, false)?;
 		Ok(LoggerGuard::file(guard))
 	}
 }
@@ -202,6 +309,7 @@ impl LogOutput {
 fn init_subscriber<W>(
 	filter_layer: reload::Layer<EnvFilter, Registry>,
 	writer: W,
+	use_ansi: bool,
 ) -> Result<(), TelemetryError>
 where
 	W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
@@ -210,6 +318,7 @@ where
 		.with(filter_layer)
 		.with(
 			fmt::layer()
+				.with_ansi(use_ansi)
 				.with_timer(CustomTimeFormat)
 				.with_target(false)
 				.with_thread_ids(true)

--- a/docs/config.md
+++ b/docs/config.md
@@ -190,7 +190,7 @@ When `log_output = "file"`, the immutable `log_rotation` field controls time-bas
 - `daily`: rotate once per day. This is the default to avoid unbounded log growth.
 - `never`: disable rotation and keep writing to the single file `{data_path}/nimbis.log`.
 
-For the rotating modes, Nimbis passes `{data_path}/nimbis.log` to the tracing rolling appender as a path template. In practice, that means logs are created in `{data_path}/` with `nimbis` as the filename prefix and `log` as the suffix, while the appender adds its own time-based component to the on-disk file name according to the selected rotation policy.
+For the rotating modes, Nimbis uses a custom rolling file implementation that manages log files directly. Logs are created in `{data_path}/` with `nimbis` as the filename prefix and `.log` as the suffix. When rotation is enabled, the appender adds timestamp-based suffixes to archived log files according to the selected rotation policy.
 
 Runtime commands such as `CONFIG SET log_rotation hourly` are rejected for the same reason: rotation is part of bootstrap-only logger setup.
 

--- a/docs/storage_design.md
+++ b/docs/storage_design.md
@@ -485,7 +485,7 @@ When a key is deleted and immediately recreated with the same name:
 New and old records are physically isolated by their versions. Even if the old `(myset, 100, m1)` hasn't been cleaned up yet, it will not conflict with the new data.
 
 #### Async Cleanup (Compaction Filter)
-Invalid data is asynchronously cleaned up by the `NimbisCompactionFilter` during the background compaction process.
+Invalid data is asynchronously cleaned up by the `CollectionCompactionFilter` during the background compaction process.
 
 **Logic**:
 1.  The Compaction Filter scans each data item.
@@ -527,7 +527,7 @@ When `EXPIRE` is called, Nimbis sets a native SlateDB TTL (`PutOptions { ttl }`)
 Collection types (Hash, List, Set, ZSet) use a "Master Expiration" pattern:
 - The expiration is stored **ONLY** in the metadata value (in `string_db`).
 - Individual members/fields/elements in their respective DBs do NOT store their own expiration.
-- When SlateDB returns `None` for the metadata key (expired), the collection is treated as non-existent. Orphaned data records are cleaned up asynchronously by the `NimbisCompactionFilter`.
+- When SlateDB returns `None` for the metadata key (expired), the collection is treated as non-existent. Orphaned data records are cleaned up asynchronously by the `CollectionCompactionFilter`.
 
 #### Expirable Trait (Code Organization)
 To avoid code duplication across different value types, the expiration logic is centralized in the `Expirable` trait defined in `crates/storage/src/expirable.rs`.
@@ -562,7 +562,7 @@ All data types store meta in `string_db` and implement `Expirable` and `MetaValu
 #### Expiration Handling
 When a read operation encounters an expired key:
 1. SlateDB's native TTL returns `None` for the key automatically.
-2. Orphaned data records (collection members under the expired version) are cleaned up asynchronously by the `NimbisCompactionFilter` during compaction.
+2. Orphaned data records (collection members under the expired version) are cleaned up asynchronously by the `CollectionCompactionFilter` during compaction.
 
 #### Unit Conversion
 - **User Interface**: `EXPIRE` and `TTL` operate in **seconds**.


### PR DESCRIPTION
- Replace tracing_appender with custom CustomRollingFile implementation
- Add Period enum for tracking minutely/hourly/daily/never rotation
- Archive active file with timestamp when rotation period changes
- Add custom timestamp format for archived files (year-month-day-hour-minute-ms)
- Add with_ansi option to disable colors for non-TTY output

This provides more control over log file rotation and archiving behavior.