### PR TITLE
feat: Add storage benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "criterion",
  "futures",
  "log",
  "object_store 0.13.1",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Available recipes:
     run *args   # Run nimbis-server
 
     [test]
+    bench       # Run storage benchmark target
     e2e-test    # Run e2e tests
     test        # Run unit tests
 ```

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -18,6 +18,11 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 rstest = { workspace = true }
 tokio = { workspace = true }
 ulid = { workspace = true }
+
+[[bench]]
+name = "benchmarks"
+harness = false

--- a/crates/storage/benches/benchmarks.rs
+++ b/crates/storage/benches/benchmarks.rs
@@ -51,7 +51,7 @@ impl BenchStore {
 		rt.block_on(storage.close())
 			.expect("failed to close storage");
 		drop(storage);
-		let _ = std::fs::remove_dir_all(&path);
+		std::fs::remove_dir_all(&path).expect("failed to remove benchmark directory");
 	}
 }
 
@@ -222,7 +222,7 @@ fn bench_storage_open(c: &mut Criterion) {
 				total += start.elapsed();
 				rt.block_on(storage.close()).expect("close should succeed");
 				drop(storage);
-				let _ = std::fs::remove_dir_all(&path);
+				std::fs::remove_dir_all(&path).expect("failed to remove benchmark directory");
 			}
 			total
 		})

--- a/crates/storage/benches/benchmarks.rs
+++ b/crates/storage/benches/benchmarks.rs
@@ -1,0 +1,209 @@
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use bytes::Bytes;
+use criterion::BatchSize;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use storage::Storage;
+use tokio::runtime::Runtime;
+
+fn bench_runtime() -> Runtime {
+	Runtime::new().expect("failed to create benchmark runtime")
+}
+
+fn fresh_storage(rt: &Runtime, name: &str) -> (Storage, PathBuf) {
+	let path = std::env::temp_dir().join(format!(
+		"nimbis_storage_bench_{}_{}",
+		name,
+		ulid::Ulid::new()
+	));
+	std::fs::create_dir_all(&path).expect("failed to create benchmark directory");
+	let storage = rt
+		.block_on(Storage::open(&path, None))
+		.expect("failed to open storage");
+	(storage, path)
+}
+
+fn cleanup_path(path: &PathBuf) {
+	let _ = std::fs::remove_dir_all(path);
+}
+
+fn bench_string_set(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "string_set");
+	let value = Bytes::from(vec![b'x'; 128]);
+	let counter = AtomicU64::new(0);
+	let mut group = c.benchmark_group("storage_string");
+
+	group.throughput(Throughput::Elements(1));
+	group.bench_function("set_128b", |b| {
+		b.iter(|| {
+			let idx = counter.fetch_add(1, Ordering::Relaxed);
+			let key = Bytes::from(format!("bench:string:set:{idx}"));
+			rt.block_on(storage.set(black_box(key), black_box(value.clone())))
+				.expect("set should succeed");
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_string_get(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "string_get");
+	let key = Bytes::from("bench:string:get:key");
+	let value = Bytes::from(vec![b'y'; 256]);
+	rt.block_on(storage.set(key.clone(), value))
+		.expect("failed to seed string key");
+	let mut group = c.benchmark_group("storage_string");
+
+	group.throughput(Throughput::Elements(1));
+	group.bench_function("get_256b", |b| {
+		b.iter(|| {
+			rt.block_on(storage.get(black_box(key.clone())))
+				.expect("get should succeed")
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_hash_hset(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "hash_hset");
+	let key = Bytes::from("bench:hash");
+	let value = Bytes::from(vec![b'h'; 64]);
+	let counter = AtomicU64::new(0);
+	let mut group = c.benchmark_group("storage_hash");
+
+	group.throughput(Throughput::Elements(1));
+	group.bench_function("hset_new_field", |b| {
+		b.iter(|| {
+			let idx = counter.fetch_add(1, Ordering::Relaxed);
+			let field = Bytes::from(format!("field:{idx}"));
+			rt.block_on(storage.hset(
+				black_box(key.clone()),
+				black_box(field),
+				black_box(value.clone()),
+			))
+			.expect("hset should succeed");
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_list_lrange(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "list_lrange");
+	let key = Bytes::from("bench:list");
+	let elements: Vec<_> = (0..256)
+		.map(|i| Bytes::from(format!("item:{i:03}")))
+		.collect();
+	rt.block_on(storage.rpush(key.clone(), elements))
+		.expect("failed to seed list");
+	let mut group = c.benchmark_group("storage_list");
+
+	group.throughput(Throughput::Elements(64));
+	group.bench_function("lrange_64_items", |b| {
+		b.iter(|| {
+			rt.block_on(storage.lrange(black_box(key.clone()), 32, 95))
+				.expect("lrange should succeed")
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_set_smembers(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "set_smembers");
+	let key = Bytes::from("bench:set");
+	let members: Vec<_> = (0..256)
+		.map(|i| Bytes::from(format!("member:{i:03}")))
+		.collect();
+	rt.block_on(storage.sadd(key.clone(), members))
+		.expect("failed to seed set");
+	let mut group = c.benchmark_group("storage_set");
+
+	group.throughput(Throughput::Elements(256));
+	group.bench_function("smembers_256_items", |b| {
+		b.iter(|| {
+			rt.block_on(storage.smembers(black_box(key.clone())))
+				.expect("smembers should succeed")
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_zset_zadd(c: &mut Criterion) {
+	let rt = bench_runtime();
+	let (storage, path) = fresh_storage(&rt, "zset_zadd");
+	let key = Bytes::from("bench:zset");
+	let counter = AtomicU64::new(0);
+	let mut group = c.benchmark_group("storage_zset");
+
+	group.throughput(Throughput::Elements(1));
+	group.bench_function("zadd_new_member", |b| {
+		b.iter(|| {
+			let idx = counter.fetch_add(1, Ordering::Relaxed);
+			let score = idx as f64;
+			let member = Bytes::from(format!("member:{idx}"));
+			rt.block_on(storage.zadd(black_box(key.clone()), black_box(vec![(score, member)])))
+				.expect("zadd should succeed");
+		})
+	});
+	group.finish();
+
+	cleanup_path(&path);
+}
+
+fn bench_storage_open(c: &mut Criterion) {
+	let rt = Arc::new(bench_runtime());
+	let mut group = c.benchmark_group("storage_open");
+
+	group.throughput(Throughput::Elements(1));
+	group.bench_function("open_empty_storage", |b| {
+		b.iter_batched(
+			|| {
+				std::env::temp_dir()
+					.join(format!("nimbis_storage_bench_open_{}", ulid::Ulid::new()))
+			},
+			|path| {
+				std::fs::create_dir_all(&path).expect("failed to create benchmark directory");
+				let storage = rt
+					.block_on(Storage::open(&path, None))
+					.expect("open should succeed");
+				rt.block_on(storage.close()).expect("close should succeed");
+				drop(storage);
+				cleanup_path(&path);
+			},
+			BatchSize::SmallInput,
+		)
+	});
+	group.finish();
+}
+
+criterion_group!(
+	benches,
+	bench_storage_open,
+	bench_string_set,
+	bench_string_get,
+	bench_hash_hset,
+	bench_list_lrange,
+	bench_set_smembers,
+	bench_zset_zadd,
+);
+criterion_main!(benches);

--- a/crates/storage/benches/benchmarks.rs
+++ b/crates/storage/benches/benchmarks.rs
@@ -1,197 +1,231 @@
+use std::future::Future;
 use std::hint::black_box;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::Instant;
 
 use bytes::Bytes;
-use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use storage::Storage;
+use storage::error::StorageError;
 use tokio::runtime::Runtime;
 
 fn bench_runtime() -> Runtime {
 	Runtime::new().expect("failed to create benchmark runtime")
 }
 
-fn fresh_storage(rt: &Runtime, name: &str) -> (Storage, PathBuf) {
-	let path = std::env::temp_dir().join(format!(
+fn bench_path(name: &str) -> PathBuf {
+	std::env::temp_dir().join(format!(
 		"nimbis_storage_bench_{}_{}",
 		name,
 		ulid::Ulid::new()
-	));
-	std::fs::create_dir_all(&path).expect("failed to create benchmark directory");
-	let storage = rt
-		.block_on(Storage::open(&path, None))
-		.expect("failed to open storage");
-	(storage, path)
+	))
 }
 
-fn cleanup_path(path: &PathBuf) {
-	let _ = std::fs::remove_dir_all(path);
+struct BenchStore {
+	rt: Runtime,
+	storage: Storage,
+	path: PathBuf,
+}
+
+impl BenchStore {
+	fn open(name: &str) -> Self {
+		let rt = bench_runtime();
+		let path = bench_path(name);
+		let storage = rt
+			.block_on(Storage::open(&path, None))
+			.expect("failed to open storage");
+
+		Self { rt, storage, path }
+	}
+
+	fn run<T>(&self, future: impl Future<Output = Result<T, StorageError>>, message: &str) -> T {
+		self.rt.block_on(future).expect(message)
+	}
+
+	fn close(self) {
+		let Self { rt, storage, path } = self;
+		rt.block_on(storage.close())
+			.expect("failed to close storage");
+		drop(storage);
+		let _ = std::fs::remove_dir_all(&path);
+	}
 }
 
 fn bench_string_set(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "string_set");
+	let bench = BenchStore::open("string_set");
 	let value = Bytes::from(vec![b'x'; 128]);
-	let counter = AtomicU64::new(0);
+	let mut next_key = 0;
 	let mut group = c.benchmark_group("storage_string");
 
 	group.throughput(Throughput::Elements(1));
 	group.bench_function("set_128b", |b| {
 		b.iter(|| {
-			let idx = counter.fetch_add(1, Ordering::Relaxed);
-			let key = Bytes::from(format!("bench:string:set:{idx}"));
-			rt.block_on(storage.set(black_box(key), black_box(value.clone())))
-				.expect("set should succeed");
+			let key = Bytes::from(format!("bench:string:set:{next_key}"));
+			next_key += 1;
+			bench.run(
+				bench.storage.set(black_box(key), black_box(value.clone())),
+				"set should succeed",
+			);
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_string_get(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "string_get");
+	let bench = BenchStore::open("string_get");
 	let key = Bytes::from("bench:string:get:key");
 	let value = Bytes::from(vec![b'y'; 256]);
-	rt.block_on(storage.set(key.clone(), value))
-		.expect("failed to seed string key");
+	bench.run(
+		bench.storage.set(key.clone(), value),
+		"failed to seed string key",
+	);
 	let mut group = c.benchmark_group("storage_string");
 
 	group.throughput(Throughput::Elements(1));
 	group.bench_function("get_256b", |b| {
 		b.iter(|| {
-			rt.block_on(storage.get(black_box(key.clone())))
-				.expect("get should succeed")
+			bench.run(
+				bench.storage.get(black_box(key.clone())),
+				"get should succeed",
+			)
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_hash_hset(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "hash_hset");
+	let bench = BenchStore::open("hash_hset");
 	let key = Bytes::from("bench:hash");
 	let value = Bytes::from(vec![b'h'; 64]);
-	let counter = AtomicU64::new(0);
+	let mut next_field = 0;
 	let mut group = c.benchmark_group("storage_hash");
 
 	group.throughput(Throughput::Elements(1));
 	group.bench_function("hset_new_field", |b| {
 		b.iter(|| {
-			let idx = counter.fetch_add(1, Ordering::Relaxed);
-			let field = Bytes::from(format!("field:{idx}"));
-			rt.block_on(storage.hset(
-				black_box(key.clone()),
-				black_box(field),
-				black_box(value.clone()),
-			))
-			.expect("hset should succeed");
+			let field = Bytes::from(format!("field:{next_field}"));
+			next_field += 1;
+			bench.run(
+				bench.storage.hset(
+					black_box(key.clone()),
+					black_box(field),
+					black_box(value.clone()),
+				),
+				"hset should succeed",
+			);
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_list_lrange(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "list_lrange");
+	let bench = BenchStore::open("list_lrange");
 	let key = Bytes::from("bench:list");
 	let elements: Vec<_> = (0..256)
 		.map(|i| Bytes::from(format!("item:{i:03}")))
 		.collect();
-	rt.block_on(storage.rpush(key.clone(), elements))
-		.expect("failed to seed list");
+	bench.run(
+		bench.storage.rpush(key.clone(), elements),
+		"failed to seed list",
+	);
 	let mut group = c.benchmark_group("storage_list");
 
 	group.throughput(Throughput::Elements(64));
 	group.bench_function("lrange_64_items", |b| {
 		b.iter(|| {
-			rt.block_on(storage.lrange(black_box(key.clone()), 32, 95))
-				.expect("lrange should succeed")
+			bench.run(
+				bench.storage.lrange(black_box(key.clone()), 32, 95),
+				"lrange should succeed",
+			)
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_set_smembers(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "set_smembers");
+	let bench = BenchStore::open("set_smembers");
 	let key = Bytes::from("bench:set");
 	let members: Vec<_> = (0..256)
 		.map(|i| Bytes::from(format!("member:{i:03}")))
 		.collect();
-	rt.block_on(storage.sadd(key.clone(), members))
-		.expect("failed to seed set");
+	bench.run(
+		bench.storage.sadd(key.clone(), members),
+		"failed to seed set",
+	);
 	let mut group = c.benchmark_group("storage_set");
 
 	group.throughput(Throughput::Elements(256));
 	group.bench_function("smembers_256_items", |b| {
 		b.iter(|| {
-			rt.block_on(storage.smembers(black_box(key.clone())))
-				.expect("smembers should succeed")
+			bench.run(
+				bench.storage.smembers(black_box(key.clone())),
+				"smembers should succeed",
+			)
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_zset_zadd(c: &mut Criterion) {
-	let rt = bench_runtime();
-	let (storage, path) = fresh_storage(&rt, "zset_zadd");
+	let bench = BenchStore::open("zset_zadd");
 	let key = Bytes::from("bench:zset");
-	let counter = AtomicU64::new(0);
+	let mut next_member = 0;
 	let mut group = c.benchmark_group("storage_zset");
 
 	group.throughput(Throughput::Elements(1));
 	group.bench_function("zadd_new_member", |b| {
 		b.iter(|| {
-			let idx = counter.fetch_add(1, Ordering::Relaxed);
-			let score = idx as f64;
-			let member = Bytes::from(format!("member:{idx}"));
-			rt.block_on(storage.zadd(black_box(key.clone()), black_box(vec![(score, member)])))
-				.expect("zadd should succeed");
+			let score = next_member as f64;
+			let member = Bytes::from(format!("member:{next_member}"));
+			next_member += 1;
+			bench.run(
+				bench
+					.storage
+					.zadd(black_box(key.clone()), black_box(vec![(score, member)])),
+				"zadd should succeed",
+			);
 		})
 	});
 	group.finish();
 
-	cleanup_path(&path);
+	bench.close();
 }
 
 fn bench_storage_open(c: &mut Criterion) {
-	let rt = Arc::new(bench_runtime());
+	let rt = bench_runtime();
 	let mut group = c.benchmark_group("storage_open");
 
 	group.throughput(Throughput::Elements(1));
 	group.bench_function("open_empty_storage", |b| {
-		b.iter_batched(
-			|| {
-				std::env::temp_dir()
-					.join(format!("nimbis_storage_bench_open_{}", ulid::Ulid::new()))
-			},
-			|path| {
-				std::fs::create_dir_all(&path).expect("failed to create benchmark directory");
+		b.iter_custom(|iters| {
+			let mut total = Duration::ZERO;
+			for _ in 0..iters {
+				let path = bench_path("open");
+				let start = Instant::now();
 				let storage = rt
 					.block_on(Storage::open(&path, None))
 					.expect("open should succeed");
+				total += start.elapsed();
 				rt.block_on(storage.close()).expect("close should succeed");
 				drop(storage);
-				cleanup_path(&path);
-			},
-			BatchSize::SmallInput,
-		)
+				let _ = std::fs::remove_dir_all(&path);
+			}
+			total
+		})
 	});
 	group.finish();
 }

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -113,11 +113,13 @@ impl Storage {
 	}
 
 	pub async fn close(&self) -> Result<(), StorageError> {
+		tokio::try_join!(
+			self.hash_db.close(),
+			self.list_db.close(),
+			self.set_db.close(),
+			self.zset_db.close(),
+		)?;
 		self.string_db.close().await?;
-		self.hash_db.close().await?;
-		self.list_db.close().await?;
-		self.set_db.close().await?;
-		self.zset_db.close().await?;
 		Ok(())
 	}
 

--- a/crates/storage/src/storage.rs
+++ b/crates/storage/src/storage.rs
@@ -112,6 +112,15 @@ impl Storage {
 		))
 	}
 
+	pub async fn close(&self) -> Result<(), StorageError> {
+		self.string_db.close().await?;
+		self.hash_db.close().await?;
+		self.list_db.close().await?;
+		self.set_db.close().await?;
+		self.zset_db.close().await?;
+		Ok(())
+	}
+
 	pub async fn flush_all(&self) -> Result<(), StorageError> {
 		// Iterate over all DBs and delete all keys
 		// Since we don't have atomic flush_all, we do best effort sequential

--- a/justfile
+++ b/justfile
@@ -19,6 +19,11 @@ e2e-test: (build "--release")
     rm -rf nimbis_store
     cd tests && go test -timeout 15m --ginkgo.v
 
+# Run storage benchmarks
+[group: 'test']
+bench:
+    cargo bench -p storage --bench benchmarks
+
 # Check all crates
 [group: 'check']
 check: check-workspace check-code-fmt check-numbered-comments


### PR DESCRIPTION
## Summary
- add a Criterion benchmark target for the `storage` crate covering open, string, hash, list, set, and zset paths
- add a `Storage::close()` helper and use it in the open benchmark so SlateDB background tasks shut down cleanly before cleanup
- expose the benchmark workflow through `just bench` and document it in the README

## Why
Issue #143 asks for storage performance testing. This adds a repeatable benchmark harness inside the repo and fixes the benchmark lifecycle bug that caused SlateDB epoch panics during repeated open and cleanup cycles.

## Validation
- `just bench`
- `cargo bench -p storage --bench benchmarks storage_open/open_empty_storage -- --exact --noplot`

Closes #143