### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   # Always enable colored output in Cargo (for better readability in CI logs)
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/marsevilspirit/nimbis/security/code-scanning/1](https://github.com/marsevilspirit/nimbis/security/code-scanning/1)

Add an explicit `permissions` block to the workflow with least privilege.  
Best single change here is to set workflow-level permissions to:

- `contents: read`

This satisfies CodeQL’s recommended minimum and preserves current functionality, since the shown steps do not require repository write access via `GITHUB_TOKEN`.  
Edit `.github/workflows/ci.yml` near the top-level keys, placing `permissions` after `on:` (or before `jobs:`) so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
