### PR TITLE
ci: add PR title checker workflow

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,20 +4,7 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "prefixes": [
-      "feat: ",
-      "fix: ",
-      "docs: ",
-      "style: ",
-      "refactor: ",
-      "perf: ",
-      "test: ",
-      "build: ",
-      "ci: ",
-      "chore: ",
-      "revert: "
-    ],
-    "regexp": "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([^)]+\\))?: .+",
+    "regexp": "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([^)]+\\))?!?: .+",
     "regexpFlags": "",
     "ignoreLabels": [
       "dependencies",

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,32 @@
+{
+  "LABEL": {
+    "name": "title needs formatting",
+    "color": "EEEEEE"
+  },
+  "CHECKS": {
+    "prefixes": [
+      "feat: ",
+      "fix: ",
+      "docs: ",
+      "style: ",
+      "refactor: ",
+      "perf: ",
+      "test: ",
+      "build: ",
+      "ci: ",
+      "chore: ",
+      "revert: "
+    ],
+    "regexp": "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([^)]+\\))?: .+",
+    "regexpFlags": "",
+    "ignoreLabels": [
+      "dependencies",
+      "skip-pr-title-check"
+    ]
+  },
+  "MESSAGES": {
+    "success": "PR title format is valid.",
+    "failure": "PR title format is invalid. Please use Conventional Commits style, e.g. feat: add xxx",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,27 @@
+name: PR Title Checker
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pull request title
+        uses: thehanimo/pr-title-checker@v1.4.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/pr-title-checker-config.json


### PR DESCRIPTION
### Motivation
- Enforce Conventional Commits-style PR titles automatically to keep repository history consistent.
- Provide an automated label for PRs that need title formatting to reduce manual triage work.

### Description
- Add workflow ` .github/workflows/pr-title-checker.yml` that runs `thehanimo/pr-title-checker@v1.4.3` on `pull_request_target` events with `contents: read` and `pull-requests: write` permissions.
- Add configuration ` .github/pr-title-checker-config.json` that defines the label `title needs formatting`, allowed prefixes, a validation `regexp`, ignored labels (`dependencies`, `skip-pr-title-check`), and success/failure messages.
- Configure the action to use `GITHUB_TOKEN` and `configuration_path: .github/pr-title-checker-config.json` so the checker can label and notify PRs according to the rules.

### Testing
- Run `python -m json.tool .github/pr-title-checker-config.json` and the JSON validated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb02e620bc8333841a0291a1543e74)