### PR TITLE
ci: add Release Drafter workflow and configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,68 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: '- No changes'
+
+categories:
+  - title: '🚀 Features'
+    labels:
+      - feature
+      - enhancement
+  - title: '🐛 Bug Fixes'
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: '🧰 Maintenance'
+    labels:
+      - chore
+      - refactor
+      - ci
+      - docs
+      - dependencies
+
+exclude-labels:
+  - skip-changelog
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+autolabeler:
+  - label: ci
+    files:
+      - '.github/**'
+  - label: docs
+    files:
+      - 'docs/**'
+      - '**/*.md'
+  - label: dependencies
+    files:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '**/Cargo.toml'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/go.mod'
+      - '**/go.sum'
+
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - feature
+      - enhancement
+  patch:
+    labels:
+      - fix
+      - bugfix
+      - bug
+      - chore
+      - refactor
+      - docs
+      - ci
+      - dependencies
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,5 +22,7 @@ jobs:
         uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
+          disable-autolabeler: ${{ github.event_name == 'push' }}
+          disable-releaser: ${{ github.event_name == 'pull_request_target' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- 自动生成并维护发布草稿以减少手动更新发布说明并确保一致的发布流程。 
- 在 PR 打开/同步时自动打标签以驱动语义化版本号解析，从而根据变更类型决定 major/minor/patch。 
- 为仓库提供一套默认的变更分类和模板，方便团队快速看到功能、修复和维护类变更。

### Description
- 新增工作流文件 `/.github/workflows/release-drafter.yml`，在 `push` 到 `main` 和 `pull_request_target` 的 `opened/reopened/synchronize` 事件上触发并运行 `release-drafter/release-drafter@v6`。 
- 在工作流中设置了 `contents` 与 `pull-requests` 的写权限，并通过 `GITHUB_TOKEN` 驱动 Draft Release 的更新。 
- 新增配置文件 `/.github/release-drafter.yml`，包含发布/标签模板、变更分类（Features/Bug Fixes/Maintenance）、排除标签、发布说明模板、自动打标规则（`ci`/`docs`/`dependencies`）以及基于标签的版本解析（major/minor/patch）。 
- 已将两份文件添加到仓库并提交（变更信息：`ci: add release drafter workflow and config`）。

### Testing
- 尝试使用内嵌 Python 脚本加载并验证 YAML 文件语法失败，因为运行环境缺少 `PyYAML`（报错 `ModuleNotFoundError: No module named 'yaml'`）。 
- 未在 CI 上执行工作流（仅添加配置文件），因此未能验证运行时行为或发布结果。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0f2a05c08333a8eecf4813d8681b)