### PR TITLE
fix(ci): remove unsupported release-drafter v7 inputs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,7 +22,5 @@ jobs:
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
-          disable-autolabeler: ${{ github.event_name == 'push' }}
-          disable-releaser: ${{ github.event_name == 'pull_request_target' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- `release-drafter/release-drafter@v7` emits `Unexpected input(s)` warnings because the `disable-autolabeler` and `disable-releaser` inputs are no longer supported, so they should be removed to silence CI warnings.

### Description
- Remove the unsupported `disable-autolabeler` and `disable-releaser` inputs from `.github/workflows/release-drafter.yml` and keep only the supported `config-name` input for `release-drafter/release-drafter@v7`.

### Testing
- Verified the change by running `rg -n "disable-autolabeler|disable-releaser|release-drafter/release-drafter@v7" .github`, inspecting the workflow with `nl -ba .github/workflows/release-drafter.yml | sed -n '1,120p'`, and confirming the unsupported inputs are removed (commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1c27ea908333a0c714a87b955157)