### PR TITLE
test: Increase mock server startup timeout to reduce CI flakiness

### DIFF
--- a/crates/nimbis/tests/mock/mock_server.rs
+++ b/crates/nimbis/tests/mock/mock_server.rs
@@ -80,8 +80,9 @@ impl Drop for MockNimbisServer {
 }
 
 fn wait_until_ready(host: &str, port: u16, data_path: &str) {
-	// Keep startup failures quick while still allowing SlateDB to initialize.
-	let ready_timeout = Duration::from_secs(5);
+	// Keep startup failures quick while still allowing slower CI hosts
+	// enough time to initialize SlateDB.
+	let ready_timeout = Duration::from_secs(15);
 	let deadline = std::time::Instant::now() + ready_timeout;
 	let mut last_error = String::from("server was not probed");
 


### PR DESCRIPTION
### Motivation
- Give slower CI hosts more time to initialize SlateDB so tests using the mock server are less likely to fail due to startup timing.

### Description
- Increase the `ready_timeout` in `wait_until_ready` from 5 seconds to 15 seconds in `crates/nimbis/tests/mock/mock_server.rs` and update the comment to reflect the change.

### Testing
- Ran `cargo test -p nimbis` which exercises the integration tests using `MockNimbisServer`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1cb0a6c083338361f07283c80b49)