### PR TITLE
ci: avoid llvm-cov clean failure in test recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,20 @@ jobs:
       run: just build --release
     
     - name: Run Unit Test
-      run: just test
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        mkdir -p target/llvm-cov-target
+        cat > target/llvm-cov-target/CACHEDIR.TAG <<'EOF'
+        Signature: 8a477f597d28d172789f06886806bc55
+        # This file is a cache directory tag created by nimbis CI.
+        EOF
+        cargo llvm-cov clean --workspace
+        just test
+
+    - name: Run Unit Test (non-coverage)
+      if: matrix.os != 'ubuntu-latest'
+      run: cargo nextest run --all
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ build *args:
 # Run unit tests with coverage generation
 [group: 'test']
 test:
-    cargo llvm-cov nextest --all --codecov --output-path codecov.json
+    cargo llvm-cov nextest --all --no-clean --codecov --output-path codecov.json
 
 # Run e2e tests
 [group: 'test']


### PR DESCRIPTION
### Motivation
- Prevent CI failures where `cargo llvm-cov` invokes `cargo clean` and aborts because a restored cache under `target/llvm-cov-target` lacks a valid `CACHEDIR.TAG`.

### Description
- Change the `test` recipe in `justfile` to run `cargo llvm-cov nextest --all --no-clean --codecov --output-path codecov.json` so the coverage tool does not perform a pre-run `cargo clean` that can fail on cached directories.

### Testing
- Attempted to run `cargo llvm-cov nextest --all --no-clean --codecov --output-path codecov.json` in the current environment but it failed because `cargo-llvm-cov` is not installed, so the coverage command could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2176b00c8333b023241ce1b4279e)