### PR TITLE
ci: remove llvm-cov target dir before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
     - name: Build Release
       run: just build --release
     
+    - name: Remove llvm-cov target dir
+      run: rm -rf target/llvm-cov-target
+
     - name: Run Unit Test
       run: just test
 


### PR DESCRIPTION
### Motivation
- Prevent stale coverage artifacts from interfering with test/coverage collection by ensuring the `target/llvm-cov-target` directory is removed before running tests.

### Description
- Add a CI step that runs `rm -rf target/llvm-cov-target` prior to `just test` in the GitHub Actions workflow (`.github/workflows/ci.yml`).

### Testing
- The workflow runs `just check`, `just build --release`, `just test` (unit tests), the Codecov upload step on Ubuntu, and `just e2e-test`, and these CI steps completed successfully after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2176b00c8333b023241ce1b4279e)