### PR TITLE
test(resp): add coverage for map/set/push frame completion paths

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,6 +44,9 @@ autolabeler:
   - label: feature
     title:
       - '/(feature|feat|add)/i'
+  - label: test
+    title:
+      - '/^(test|tests)(\(.+\))?:/i'
   - label: ci
     files:
       - '.github/**'

--- a/crates/resp/src/parser.rs
+++ b/crates/resp/src/parser.rs
@@ -662,48 +662,36 @@ mod tests {
 	fn test_parse_map_non_empty() {
 		let mut buf = BytesMut::from(&b"%2\r\n+first\r\n:1\r\n+second\r\n:2\r\n"[..]);
 		let value = parse(&mut buf).unwrap();
-
-		if let RespValue::Map(map) = value {
-			assert_eq!(map.len(), 2);
-			assert_eq!(
-				map.get(&RespValue::SimpleString(Bytes::from("first"))),
-				Some(&RespValue::Integer(1))
-			);
-			assert_eq!(
-				map.get(&RespValue::SimpleString(Bytes::from("second"))),
-				Some(&RespValue::Integer(2))
-			);
-		} else {
-			panic!("Expected Map, got {:?}", value);
-		}
+		let expected = HashMap::from([
+			(RespValue::simple_string("first"), RespValue::integer(1)),
+			(RespValue::simple_string("second"), RespValue::integer(2)),
+		]);
+		assert_eq!(value, RespValue::Map(expected));
+		assert!(buf.is_empty(), "Buffer should be empty after parsing");
 	}
 
 	#[test]
 	fn test_parse_set_non_empty() {
 		let mut buf = BytesMut::from(&b"~2\r\n+orange\r\n+apple\r\n"[..]);
 		let value = parse(&mut buf).unwrap();
-
-		if let RespValue::Set(set) = value {
-			assert_eq!(set.len(), 2);
-			assert!(set.contains(&RespValue::SimpleString(Bytes::from("orange"))));
-			assert!(set.contains(&RespValue::SimpleString(Bytes::from("apple"))));
-		} else {
-			panic!("Expected Set, got {:?}", value);
-		}
+		let expected = HashSet::from([
+			RespValue::simple_string("orange"),
+			RespValue::simple_string("apple"),
+		]);
+		assert_eq!(value, RespValue::Set(expected));
+		assert!(buf.is_empty(), "Buffer should be empty after parsing");
 	}
 
 	#[test]
 	fn test_parse_push_non_empty() {
 		let mut buf = BytesMut::from(&b">2\r\n+pubsub\r\n+message\r\n"[..]);
 		let value = parse(&mut buf).unwrap();
-
-		if let RespValue::Push(arr) = value {
-			assert_eq!(arr.len(), 2);
-			assert_eq!(arr[0], RespValue::SimpleString(Bytes::from("pubsub")));
-			assert_eq!(arr[1], RespValue::SimpleString(Bytes::from("message")));
-		} else {
-			panic!("Expected Push, got {:?}", value);
-		}
+		let expected = vec![
+			RespValue::simple_string("pubsub"),
+			RespValue::simple_string("message"),
+		];
+		assert_eq!(value, RespValue::Push(expected));
+		assert!(buf.is_empty(), "Buffer should be empty after parsing");
 	}
 
 	use rstest::rstest;

--- a/crates/resp/src/parser.rs
+++ b/crates/resp/src/parser.rs
@@ -686,11 +686,13 @@ mod tests {
 	fn test_parse_push_non_empty() {
 		let mut buf = BytesMut::from(&b">2\r\n+pubsub\r\n+message\r\n"[..]);
 		let value = parse(&mut buf).unwrap();
-		let expected = vec![
-			RespValue::simple_string("pubsub"),
-			RespValue::simple_string("message"),
-		];
-		assert_eq!(value, RespValue::Push(expected));
+		assert_eq!(
+			value,
+			RespValue::Push(vec![
+				RespValue::simple_string("pubsub"),
+				RespValue::simple_string("message"),
+			])
+		);
 		assert!(buf.is_empty(), "Buffer should be empty after parsing");
 	}
 

--- a/crates/resp/src/parser.rs
+++ b/crates/resp/src/parser.rs
@@ -658,6 +658,54 @@ mod tests {
 		}
 	}
 
+	#[test]
+	fn test_parse_map_non_empty() {
+		let mut buf = BytesMut::from(&b"%2\r\n+first\r\n:1\r\n+second\r\n:2\r\n"[..]);
+		let value = parse(&mut buf).unwrap();
+
+		if let RespValue::Map(map) = value {
+			assert_eq!(map.len(), 2);
+			assert_eq!(
+				map.get(&RespValue::SimpleString(Bytes::from("first"))),
+				Some(&RespValue::Integer(1))
+			);
+			assert_eq!(
+				map.get(&RespValue::SimpleString(Bytes::from("second"))),
+				Some(&RespValue::Integer(2))
+			);
+		} else {
+			panic!("Expected Map, got {:?}", value);
+		}
+	}
+
+	#[test]
+	fn test_parse_set_non_empty() {
+		let mut buf = BytesMut::from(&b"~2\r\n+orange\r\n+apple\r\n"[..]);
+		let value = parse(&mut buf).unwrap();
+
+		if let RespValue::Set(set) = value {
+			assert_eq!(set.len(), 2);
+			assert!(set.contains(&RespValue::SimpleString(Bytes::from("orange"))));
+			assert!(set.contains(&RespValue::SimpleString(Bytes::from("apple"))));
+		} else {
+			panic!("Expected Set, got {:?}", value);
+		}
+	}
+
+	#[test]
+	fn test_parse_push_non_empty() {
+		let mut buf = BytesMut::from(&b">2\r\n+pubsub\r\n+message\r\n"[..]);
+		let value = parse(&mut buf).unwrap();
+
+		if let RespValue::Push(arr) = value {
+			assert_eq!(arr.len(), 2);
+			assert_eq!(arr[0], RespValue::SimpleString(Bytes::from("pubsub")));
+			assert_eq!(arr[1], RespValue::SimpleString(Bytes::from("message")));
+		} else {
+			panic!("Expected Push, got {:?}", value);
+		}
+	}
+
 	use rstest::rstest;
 
 	#[rstest]


### PR DESCRIPTION
### Motivation
- `RespParser::handle_parsed_value` had untested branches for `Frame::Map`, `Frame::Set`, and `Frame::Push`, so add focused unit tests to ensure collection frame assembly and completion behave correctly.

### Description
- Added three unit tests in `crates/resp/src/parser.rs`: `test_parse_map_non_empty`, `test_parse_set_non_empty`, and `test_parse_push_non_empty`, which parse non-empty RESP3 `Map`, `Set`, and `Push` payloads and assert the final `RespValue` contents.

### Testing
- Ran `cargo test -p resp test_parse_map_non_empty`, `cargo test -p resp test_parse_set_non_empty`, and `cargo test -p resp test_parse_push_non_empty`, and all targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb340955e48333bc49c26f8eca84d6)