### PR TITLE
ci: add refactor autolabeler rule

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,6 +44,9 @@ autolabeler:
   - label: feature
     title:
       - '/(feature|feat|add)/i'
+  - label: refactor
+    title:
+      - '/^(refactor)(\(.+\))?:/i'
   - label: test
     title:
       - '/^(test|tests)(\(.+\))?:/i'


### PR DESCRIPTION
### Motivation
- Ensure PRs using Conventional Commit `refactor:` or `refactor(scope):` are automatically categorized with the `refactor` label during release drafting.

### Description
- Add a new `autolabeler` rule in `.github/release-drafter.yml` that matches `/^(refactor)(\(.+\))?:/i` and applies the `refactor` label.

### Testing
- Verified the file change with `git diff -- .github/release-drafter.yml` which succeeded.
- Verified repository status with `git status --short` which succeeded.
- Created the commit `ci: add refactor autolabeler rule` and invoked PR creation, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb3d84868883338d5c584ca14ce712)