### PR TITLE
ci: run release drafter autolabeler for PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,17 @@ permissions:
   pull-requests: write
 
 jobs:
+  auto_label:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Release Drafter Autolabeler
+        uses: release-drafter/release-drafter/autolabeler@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   update_release_draft:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Drafter


### PR DESCRIPTION
## Summary
- split Release Drafter workflow so PR events run the autolabeler action
- keep draft release updates scoped to pushes on main

## Why
The existing workflow ran the main Release Drafter action on pull_request_target, which updated the draft release but did not apply PR labels. The autolabeler is a separate action path in v7.

## Validation
- git diff --check
- ruby YAML parse for .github/workflows/release-drafter.yml