### PR TITLE
ci: skip Codecov upload when CODECOV_TOKEN is unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       run: just test
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v5
       with:
         files: ./codecov.json


### PR DESCRIPTION
### Motivation

- Fixed an issue where the `Upload coverage to Codecov` step caused the `Build and Test (ubuntu-latest)` job to fail when the repository secrets were unavailable in contexts like Dependabot.

### Description

- Changed the trigger condition for the Codecov step in `.github/workflows/ci.yml` to `if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''`, ensuring the upload only occurs when `CODECOV_TOKEN` is available.

### Testing

- Confirmed the failure point as `Upload coverage to Codecov` by checking the workflow's check-runs via the GitHub API, and verified that the modified YAML parsing worked correctly using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml')"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0bb83e848333816636d1058d8b19)