### PR TITLE
fix(ci): Fix error in GitHub Actions involving direct references to secrets within `if` expressions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
     - uses: actions/checkout@v6
@@ -63,7 +61,9 @@ jobs:
       run: just test
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       uses: codecov/codecov-action@v6
       with:
         files: ./codecov.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
     - uses: actions/checkout@v6
@@ -61,14 +63,14 @@ jobs:
       run: just test
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
+      if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v6
       with:
         files: ./codecov.json
         flags: rust
         name: rust-coverage
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ env.CODECOV_TOKEN }}
 
     - name: Run E2E Test
       run: just e2e-test


### PR DESCRIPTION
### Motivation

- Fixed an issue that caused workflow parsing to fail (`Unrecognized named-value: 'secrets'`) due to directly referencing `secrets.CODECOV_TOKEN` in `if` statements.

### Description

- Added `env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` at the `build` job level, and changed the `if` condition and `token` parameter in the Codecov step from `secrets.CODECOV_TOKEN` to `env.CODECOV_TOKEN` to avoid directly referencing `secrets` in unsupported contexts.

### Testing

- Running `YAML.load_file('.github/workflows/ci.yml')` in Ruby successfully parses and outputs `YAML parse ok`, but attempting to parse it using Python's `yaml` results in an error: `No module named 'yaml'` due to a missing `PyYAML` module in the environment.

------ 

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef12c50a588333961afefb9eb50a62)