### PR TITLE
ci: Persist Rust dependency cache on CI job failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       with:
         # Cache key includes the OS to separate caches per platform
         shared-key: ${{ runner.os }}-rust
+        # Persist cache even when Windows job fails midway, so next runs can still restore.
+        cache-on-failure: true
 
     - name: Install just
       uses: taiki-e/install-action@just


### PR DESCRIPTION
### Motivation
- Ensure Rust dependency cache is preserved for subsequent runs even when a job (notably on Windows) fails midway by enabling cache persistence on failure.

### Description
- Add `cache-on-failure: true` to the `Swatinem/rust-cache@v2` step in `.github/workflows/ci.yml` so the Rust cache is persisted when a job fails.

### Testing
- No automated tests were executed specifically for this change; the CI workflow continues to run `just check`, `just build --release`, and `just test` when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef182bc2408333bed1ccd9e340cc18)