### PR TITLE
ci: Split the build matrix into cross-platform compilation and full Linux testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,38 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and Test
+  build-cross-platform:
+    name: build-cross-platform (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust Toolchain
+      uses: dtolnay/rust-toolchain@nightly
+
+    - name: Cache Rust Dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        # Cache key includes the OS to separate caches per platform
+        shared-key: ${{ runner.os }}-rust
+
+    - name: Install just
+      uses: taiki-e/install-action@just
+
+    - name: Check
+      run: just check
+
+    - name: Build Release
+      run: just build --release
+
+  test-linux-full:
+    name: test-linux-full
+    runs-on: ubuntu-latest
+    needs: build-cross-platform
 
     steps:
     - uses: actions/checkout@v6
@@ -51,17 +77,14 @@ jobs:
         cache: true
         cache-dependency-path: tests/go.sum
 
-    - name: Check
-      run: just check
-    
-    - name: Build Release
-      run: just build --release
-    
     - name: Run Unit Test
       run: just test
 
+    - name: Run E2E Test
+      run: just e2e-test
+
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != ''
+      if: secrets.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v6
       with:
         files: ./codecov.json
@@ -69,6 +92,3 @@ jobs:
         name: rust-coverage
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Run E2E Test
-      run: just e2e-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   build-cross-platform:
     name: build-cross-platform (${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -45,7 +46,6 @@ jobs:
   test-linux-full:
     name: test-linux-full
     runs-on: ubuntu-latest
-    needs: build-cross-platform
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
       with:
         # Cache key includes the OS to separate caches per platform
         shared-key: ${{ runner.os }}-rust
+        # Persist cache on failures for better recovery in subsequent runs.
+        cache-on-failure: true
 
     - name: Install just
       uses: taiki-e/install-action@just
@@ -84,7 +86,7 @@ jobs:
       run: just e2e-test
 
     - name: Upload coverage to Codecov
-      if: secrets.CODECOV_TOKEN != ''
+      if: github.event_name == 'push' && secrets.CODECOV_TOKEN != ''
       uses: codecov/codecov-action@v6
       with:
         files: ./codecov.json


### PR DESCRIPTION
### Motivation
- Reduce the execution of time-consuming tests on Windows/macOS to lower matrix costs, while retaining cross-platform build validation to catch platform-specific build regressions.
- Consolidate full testing (Unit + E2E) and coverage uploading onto a single Ubuntu runner to ensure comprehensive quality gates on Linux.
- Align the required checks for branch protection to cover both cross-platform builds (specifically the Windows entry) and full Linux testing to prevent quality regressions.

### Description
- Split the original `build` matrix job into `build-cross-platform` (matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`; performs only `just check` + `just build --release`) and `test-linux-full` (runs only on `ubuntu-latest`; `needs: build-cross-platform`).
- Move `Run Unit Test`, `Run E2E Test`, and `Upload coverage to Codecov` from the matrix job to `test-linux-full`, and update the Codecov condition to check only for `secrets.CODECOV_TOKEN` (no longer relying on matrix variables).
- Retain the Windows build validation step to guard against build regressions, but avoid executing time-consuming test steps on Windows/macOS to conserve resources.
- Changes have been committed and a PR created (the PR description suggests manually updating the required checks in the GitHub branch protection settings to `build-cross-platform (windows-latest)` and `test-linux-full`, as no codifiable branch protection configuration files were found within the repository).

### Testing
- Ran `git diff --check` to verify workspace differences and whitespace issues; the command succeeded with no errors.
- Used `rg` to search the repository for configuration files related to branch protection or required checks, but found no modifiable repository-hosted configurations (this was to verify whether protection rules could be updated directly via code).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1872fa908333a8b779eab8487026)