### PR TITLE
fix: Fix EnvFilter validation for logger reload

### DIFF
--- a/nimbis-telemetry/src/logger.rs
+++ b/nimbis-telemetry/src/logger.rs
@@ -92,13 +92,12 @@ impl Logger {
 
 	/// Reload the log level dynamically.
 	pub fn reload_log_level(&self, level: &str) -> Result<(), TelemetryError> {
-		validate_log_level(level)?;
+		let new_filter = validate_log_level(level)?;
 
 		let Some(reload_handle) = self.reload_handle.as_ref() else {
 			return Ok(());
 		};
 
-		let new_filter = EnvFilter::new(level.to_lowercase());
 		reload_handle
 			.reload(new_filter)
 			.map_err(|e| TelemetryError::ReloadFailed(e.to_string()))
@@ -390,15 +389,8 @@ where
 		.map_err(|e| TelemetryError::InitFailed(e.to_string()))
 }
 
-pub fn validate_log_level(level: &str) -> Result<(), TelemetryError> {
-	const VALID_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
-	let level_lower = level.to_lowercase();
-
-	if !VALID_LEVELS.contains(&level_lower.as_str()) {
-		Err(TelemetryError::InvalidLogLevel(level.to_string()))
-	} else {
-		Ok(())
-	}
+pub fn validate_log_level(level: &str) -> Result<EnvFilter, TelemetryError> {
+	EnvFilter::try_new(level).map_err(|_| TelemetryError::InvalidLogLevel(level.to_string()))
 }
 
 #[cfg(test)]
@@ -462,21 +454,26 @@ mod tests {
 	#[case("info")]
 	#[case("warn")]
 	#[case("error")]
+	#[case("off")]
+	#[case("tokio")]
+	#[case("[my_span]")]
+	#[case("3")]
 	#[case("TRACE")] // Test case insensitivity
 	#[case("DEBUG")]
 	#[case("INFO")]
 	#[case("DeBuG")] // Mixed case
+	#[case("nimbis=debug,tokio=warn")]
 	fn test_valid_log_levels(#[case] level: &str) {
 		assert!(validate_log_level(level).is_ok());
 	}
 
 	/// Test that invalid log levels are rejected
 	#[rstest]
-	#[case("invalid")]
-	#[case("foo")]
-	#[case("bar")]
-	#[case("warning")] // Common mistake (should be "warn")
-	#[case("critical")] // Common mistake (not a standard Rust log level)
+	#[case("nimbis=invalid")]
+	#[case("tokio=warning")]
+	#[case("hyper=critical")]
+	#[case("nimbis==debug")]
+	#[case("[")]
 	fn test_invalid_log_levels(#[case] level: &str) {
 		let result = validate_log_level(level);
 		assert!(

--- a/nimbis-telemetry/src/logger.rs
+++ b/nimbis-telemetry/src/logger.rs
@@ -75,7 +75,7 @@ impl Logger {
 
 	/// Initialize the logger with the provided log level.
 	pub fn init(level: &str, output: LogOutput) -> Result<Self, TelemetryError> {
-		let env_filter = validate_log_level(level)?;
+		let env_filter = parse_env_filter(level)?;
 
 		let is_file = output.is_file();
 		let (filter_layer, reload_handle) = reload::Layer::new(env_filter);
@@ -92,7 +92,7 @@ impl Logger {
 
 	/// Reload the log level dynamically.
 	pub fn reload_log_level(&self, level: &str) -> Result<(), TelemetryError> {
-		let new_filter = validate_log_level(level)?;
+		let new_filter = parse_env_filter(level)?;
 
 		let Some(reload_handle) = self.reload_handle.as_ref() else {
 			return Ok(());
@@ -389,8 +389,12 @@ where
 		.map_err(|e| TelemetryError::InitFailed(e.to_string()))
 }
 
-pub fn validate_log_level(level: &str) -> Result<EnvFilter, TelemetryError> {
-	EnvFilter::try_new(level).map_err(|_| TelemetryError::InvalidLogLevel(level.to_string()))
+fn parse_env_filter(level: &str) -> Result<EnvFilter, TelemetryError> {
+	EnvFilter::try_new(level).map_err(|e| TelemetryError::InvalidLogLevel(format!("{level}: {e}")))
+}
+
+pub fn validate_log_level(level: &str) -> Result<(), TelemetryError> {
+	parse_env_filter(level).map(|_| ())
 }
 
 #[cfg(test)]
@@ -490,6 +494,17 @@ mod tests {
 			"Expected InvalidLogLevel for: {}",
 			level
 		);
+	}
+
+	#[test]
+	fn test_invalid_log_level_includes_parse_error() {
+		let result = validate_log_level("nimbis=verbose");
+
+		assert!(matches!(
+			result,
+			Err(TelemetryError::InvalidLogLevel(message))
+				if message.starts_with("nimbis=verbose:") && message.len() > "nimbis=verbose:".len()
+		));
 	}
 
 	// CustomRollingFile tests

--- a/nimbis/src/config.rs
+++ b/nimbis/src/config.rs
@@ -513,7 +513,7 @@ log_level = "nimbis=verbose"
 
 		let err = load_from_file(&file_path).unwrap_err();
 		assert!(
-			matches!(err, ConfigError::Telemetry(TelemetryError::InvalidLogLevel(v)) if v == "nimbis=verbose")
+			matches!(err, ConfigError::Telemetry(TelemetryError::InvalidLogLevel(v)) if v.starts_with("nimbis=verbose:"))
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Parse log level updates with `EnvFilter::try_new` instead of a hardcoded level whitelist
- Reuse the parsed filter for reloads without lowercasing the expression
- Expand unit coverage for valid EnvFilter directives and invalid syntax cases

## Testing
- `cargo test -p nimbis-telemetry log_levels -- --nocapture`
- `cargo fmt --check`
- `just check`