### PR TITLE
refactor: CI into parallel jobs and co-locate release build with E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ runner.os }}-rust
+        shared-key: ${{ runner.os }}-rust-check
         cache-on-failure: true
 
     - name: Install just
@@ -59,7 +59,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ runner.os }}-rust
+        shared-key: ${{ runner.os }}-rust-unit-test
         cache-on-failure: true
 
     - name: Install just
@@ -104,7 +104,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        shared-key: ${{ runner.os }}-rust
+        shared-key: ${{ runner.os }}-rust-build-release-e2e
         cache-on-failure: true
 
     - name: Install just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        # Cache key includes the OS to separate caches per platform
         shared-key: ${{ runner.os }}-rust
-        # Persist cache even when Windows job fails midway, so next runs can still restore.
         cache-on-failure: true
 
     - name: Install just
@@ -61,9 +59,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        # Cache key includes the OS to separate caches per platform
         shared-key: ${{ runner.os }}-rust
-        # Persist cache even when Windows job fails midway, so next runs can still restore.
         cache-on-failure: true
 
     - name: Install just
@@ -108,9 +104,7 @@ jobs:
     - name: Cache Rust Dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        # Cache key includes the OS to separate caches per platform
         shared-key: ${{ runner.os }}-rust
-        # Persist cache even when Windows job fails midway, so next runs can still restore.
         cache-on-failure: true
 
     - name: Install just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and Test
+  check:
+    name: Check
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust Toolchain
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: llvm-tools-preview
+
+    - name: Cache Rust Dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        # Cache key includes the OS to separate caches per platform
+        shared-key: ${{ runner.os }}-rust
+        # Persist cache even when Windows job fails midway, so next runs can still restore.
+        cache-on-failure: true
+
+    - name: Install just
+      uses: taiki-e/install-action@just
+
+    - name: Check
+      run: just check
+
+  unit_test:
+    name: Unit Test
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -46,19 +75,6 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Setup Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: '1.25'
-        cache: true
-        cache-dependency-path: e2e-test/go.sum
-
-    - name: Check
-      run: just check
-    
-    - name: Build Release
-      run: just build --release
-    
     - name: Run Unit Test
       run: just test
 
@@ -73,6 +89,42 @@ jobs:
         name: rust-coverage
         fail_ci_if_error: true
         token: ${{ env.CODECOV_TOKEN }}
+
+  build_release_e2e:
+    name: Build Release and E2E Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Rust Toolchain
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: llvm-tools-preview
+
+    - name: Cache Rust Dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        # Cache key includes the OS to separate caches per platform
+        shared-key: ${{ runner.os }}-rust
+        # Persist cache even when Windows job fails midway, so next runs can still restore.
+        cache-on-failure: true
+
+    - name: Install just
+      uses: taiki-e/install-action@just
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+        cache: true
+        cache-dependency-path: e2e-test/go.sum
+
+    - name: Build Release
+      run: just build --release
 
     - name: Run E2E Test
       run: just e2e-test

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ test:
 
 # Run e2e tests
 [group: 'test']
-e2e-test: (build "--release")
+e2e-test:
     rm -rf nimbis_store
     cd e2e-test && go test -timeout 15m --ginkgo.v
 


### PR DESCRIPTION
## Summary
- split the previous combined `build` workflow job into three independent jobs: `check`, `unit_test`, and `build_release_e2e`
- keep `Build Release` and `Run E2E Test` in the same job so E2E runs immediately after the release build in one runner
- preserve matrix execution on `ubuntu-latest`, `macos-latest`, and `windows-latest` for all three jobs
- retain Codecov upload behavior in the unit test job for `ubuntu-latest` on push events

## Why
This allows `check`, `unit_test`, and `build_release_e2e` to run in parallel at the workflow level while ensuring E2E tests use the release build produced in the same job context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04fccb4f08333b178ea9d77c639b2)