### PR TITLE
chore: Enable thin LTO for workspace release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,6 @@ criterion = { version = "0.8.1", features = ["html_reports"] }
 rstest = "0.26.1"
 serial_test = { version = "3.2.0", features = ["file_locks"] }
 ulid = "1.2.1"
+
+[profile.release]
+lto = "thin"


### PR DESCRIPTION
### Motivation
- Improve release build performance and cross-crate optimization by enabling link-time optimization (LTO) at the workspace level.

### Description
- Add a workspace-level `[profile.release]` section to `Cargo.toml` and set `lto = "thin"` to enable thin LTO for release builds.

### Testing
- Ran `cargo check --workspace` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f068380c648333be9c9b4c1ef951fa)