### PR TITLE
feat: add production-grade tracing runtime configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +436,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1996,6 +2017,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -2008,9 +2030,13 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
+ "base64",
+ "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
+ "serde",
+ "serde_json",
  "tonic",
  "tonic-prost",
 ]
@@ -2305,6 +2331,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3654,6 +3704,12 @@ dependencies = [
  "serde",
  "web-time",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ memchr = "2.8.0"
 num_cpus = "1.17.0"
 object_store = "0.13.1"
 opentelemetry = "0.31.0"
-opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
+opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "http-proto", "http-json", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
 quote = "1.0.45"
 regex = "1.12.2"

--- a/config/config_template.toml
+++ b/config/config_template.toml
@@ -29,6 +29,22 @@ trace_enabled = false
 # Required when trace_enabled = true, and must be an http or https URL with a host.
 trace_endpoint = ""
 
+# Trace sampling ratio between 0.0 and 1.0.
+# - 0.0 disables collection of command spans while keeping trace context wiring enabled.
+# - 1.0 samples everything.
+# Default is 0.0001 (0.01%) for production safety.
+trace_sampling_ratio = 0.0001
+
+# OTLP transport protocol: "grpc", "http_binary", or "http_json".
+trace_protocol = "grpc"
+
+# Export timeout in seconds for each OTLP push.
+trace_export_timeout_seconds = 10
+
+# Collector report interval in milliseconds.
+# Smaller values flush more frequently and reduce batch size pressure.
+trace_report_interval_ms = 1000
+
 # Number of worker threads (default: number of CPU cores)
 # worker_threads = 8
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,22 @@ pub struct MyConfig {
     // Immutable OpenTelemetry endpoint used when trace collection is enabled
     #[online_config(immutable)]
     pub trace_endpoint: String,
+
+    // Immutable startup-only sampling ratio (0.0 - 1.0)
+    #[online_config(immutable)]
+    pub trace_sampling_ratio: f64,
+
+    // Immutable startup-only OTLP transport protocol
+    #[online_config(immutable)]
+    pub trace_protocol: String,
+
+    // Immutable startup-only OTLP exporter timeout (seconds)
+    #[online_config(immutable)]
+    pub trace_export_timeout_seconds: u64,
+
+    // Immutable startup-only collector flush/report interval (milliseconds)
+    #[online_config(immutable)]
+    pub trace_report_interval_ms: u64,
 }
 
 impl MyConfig {
@@ -219,7 +235,29 @@ The immutable `trace_enabled` field controls whether Nimbis initializes the fast
 
 When `trace_enabled = true`, the immutable `trace_endpoint` field is required and must be a valid `http` or `https` URL with a host, such as `http://localhost:4317`. Traces are exported to that OpenTelemetry endpoint via gRPC.
 
+Additional startup-only trace controls:
+
+- `trace_sampling_ratio`: decimal value in `[0.0, 1.0]`. This controls command-span sampling rate.
+- `trace_protocol`: one of `grpc`, `http_binary`, `http_json`.
+- `trace_export_timeout_seconds`: timeout for each OTLP export request.
+- `trace_report_interval_ms`: maximum interval between collector report cycles; reducing this can reduce burst size.
+
 When `trace_enabled = false`, `trace_endpoint` may be left empty. This is the default configuration and disables trace export entirely.
+
+Environment variables can override file-based trace configuration at startup:
+
+- `NIMBIS_TRACE_ENABLED`
+- `NIMBIS_TRACE_ENDPOINT`
+- `NIMBIS_TRACE_SAMPLING_RATIO`
+- `NIMBIS_TRACE_PROTOCOL`
+- `NIMBIS_TRACE_EXPORT_TIMEOUT_SECONDS`
+- `NIMBIS_TRACE_REPORT_INTERVAL_MS`
+
+Recommended profiles:
+
+- Local development: `trace_enabled=true`, `trace_sampling_ratio=1.0`, `trace_report_interval_ms=500`, pointing to a local collector.
+- Production baseline: `trace_enabled=true`, `trace_sampling_ratio=0.0001` (0.01%), `trace_protocol=grpc`, `trace_export_timeout_seconds=10`, `trace_report_interval_ms=1000`.
+- Emergency high-load safety: temporarily set `trace_enabled=false` or reduce `trace_sampling_ratio` toward `0.0`.
 
 Runtime commands such as `CONFIG SET trace_enabled true` or `CONFIG SET trace_endpoint http://localhost:4317` are rejected because fastrace collector setup is part of bootstrap-only telemetry initialization.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -186,6 +186,18 @@ pub struct ServerConfig {
     pub trace_endpoint: String,
 
     #[online_config(immutable)]
+    pub trace_sampling_ratio: f64,
+
+    #[online_config(immutable)]
+    pub trace_protocol: String,
+
+    #[online_config(immutable)]
+    pub trace_export_timeout_seconds: u64,
+
+    #[online_config(immutable)]
+    pub trace_report_interval_ms: u64,
+
+    #[online_config(immutable)]
     pub worker_threads: usize,
 }
 ```

--- a/e2e-test/config_test.go
+++ b/e2e-test/config_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"runtime"
 	"strconv"
 
 	"github.com/marsevilspirit/nimbis/e2e-test/util"
@@ -76,8 +75,9 @@ var _ = Describe("CONFIG Commands", func() {
 			result, err := rdb.ConfigGet(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
 			// host, port, data_path, save, appendonly, log_level, log_output,
-			// log_rotation, trace_enabled, trace_endpoint, worker_threads
-			Expect(result).To(HaveLen(11))
+			// log_rotation, trace_enabled, trace_endpoint, trace_sampling_ratio,
+			// trace_protocol, trace_export_timeout_seconds, trace_report_interval_ms, worker_threads
+			Expect(result).To(HaveLen(15))
 			Expect(result).To(HaveKeyWithValue("host", "127.0.0.1"))
 			Expect(result).To(HaveKeyWithValue("port", "6379"))
 			Expect(result).To(HaveKeyWithValue("data_path", "./nimbis_store"))
@@ -88,7 +88,15 @@ var _ = Describe("CONFIG Commands", func() {
 			Expect(result).To(HaveKeyWithValue("log_rotation", "daily"))
 			Expect(result).To(HaveKeyWithValue("trace_enabled", "false"))
 			Expect(result).To(HaveKeyWithValue("trace_endpoint", ""))
-			Expect(result).To(HaveKeyWithValue("worker_threads", strconv.Itoa(runtime.NumCPU())))
+			Expect(result).To(HaveKeyWithValue("trace_sampling_ratio", "0.0001"))
+			Expect(result).To(HaveKeyWithValue("trace_protocol", "grpc"))
+			Expect(result).To(HaveKeyWithValue("trace_export_timeout_seconds", "10"))
+			Expect(result).To(HaveKeyWithValue("trace_report_interval_ms", "1000"))
+			workerThreads, ok := result["worker_threads"]
+			Expect(ok).To(BeTrue())
+			workerThreadsInt, convErr := strconv.Atoi(workerThreads)
+			Expect(convErr).NotTo(HaveOccurred())
+			Expect(workerThreadsInt).To(BeNumerically(">", 0))
 		})
 
 		It("should match fields with prefix wildcard", func() {

--- a/nimbis-telemetry/src/manager.rs
+++ b/nimbis-telemetry/src/manager.rs
@@ -17,11 +17,10 @@ impl TelemetryManager {
 	pub fn init(
 		level: &str,
 		output: logger::LogOutput,
-		trace_enabled: bool,
-		trace_endpoint: String,
+		trace_config: tracer::TracerConfig,
 	) -> Result<Self, TelemetryError> {
 		let logger = logger::Logger::init(level, output)?;
-		let tracer = tracer::Tracer::init(trace_enabled, trace_endpoint)?;
+		let tracer = tracer::Tracer::init(trace_config)?;
 		Ok(Self { logger, tracer })
 	}
 

--- a/nimbis-telemetry/src/tracer.rs
+++ b/nimbis-telemetry/src/tracer.rs
@@ -15,6 +15,16 @@ pub struct Tracer {
 	enabled: bool,
 }
 
+#[derive(Debug, Clone)]
+pub struct TracerConfig {
+	pub enabled: bool,
+	pub endpoint: String,
+	pub sampling_ratio: f64,
+	pub protocol: String,
+	pub export_timeout_seconds: u64,
+	pub report_interval_ms: u64,
+}
+
 impl Tracer {
 	pub fn disabled() -> Self {
 		Self { enabled: false }
@@ -24,20 +34,33 @@ impl Tracer {
 	///
 	/// Callers must validate that an enabled tracer has a non-empty OTLP
 	/// endpoint.
-	pub fn init(enabled: bool, endpoint: String) -> Result<Self, TelemetryError> {
-		if enabled {
-			if endpoint.is_empty() {
+	pub fn init(config: TracerConfig) -> Result<Self, TelemetryError> {
+		if config.enabled {
+			if config.endpoint.is_empty() {
 				return Err(TelemetryError::TraceInitFailed(
 					"trace_endpoint must be set when trace collection is enabled".into(),
 				));
 			}
 
+			let protocol = match config.protocol.trim().to_ascii_lowercase().as_str() {
+				"grpc" => opentelemetry_otlp::Protocol::Grpc,
+				"http_binary" => opentelemetry_otlp::Protocol::HttpBinary,
+				"http_json" => opentelemetry_otlp::Protocol::HttpJson,
+				invalid => {
+					return Err(TelemetryError::TraceInitFailed(format!(
+						"invalid trace protocol: {invalid}. expected grpc/http_binary/http_json"
+					)));
+				}
+			};
+
 			let reporter = OpenTelemetryReporter::new(
 				SpanExporter::builder()
 					.with_tonic()
-					.with_endpoint(endpoint.clone())
-					.with_protocol(opentelemetry_otlp::Protocol::Grpc)
-					.with_timeout(std::time::Duration::from_secs(10)) // Use default 10s if constant is not easily accessible
+					.with_endpoint(config.endpoint.clone())
+					.with_protocol(protocol)
+					.with_timeout(std::time::Duration::from_secs(
+						config.export_timeout_seconds,
+					))
 					.build()
 					.expect("initialize otlp exporter"),
 				Cow::Owned(
@@ -49,16 +72,26 @@ impl Tracer {
 					.with_version(env!("CARGO_PKG_VERSION"))
 					.build(),
 			);
-			fastrace::set_reporter(reporter, Config::default());
+			fastrace::set_reporter(
+				reporter,
+				Config::default()
+					.report_interval(std::time::Duration::from_millis(config.report_interval_ms)),
+			);
 			log::info!(
-				"Tracer initialized successfully with OTLP exporter to {}",
-				endpoint
+				"Tracer initialized successfully with OTLP exporter to {} (protocol={}, sampling_ratio={}, timeout={}s, report_interval={}ms)",
+				config.endpoint,
+				config.protocol,
+				config.sampling_ratio,
+				config.export_timeout_seconds,
+				config.report_interval_ms
 			);
 		} else {
 			log::info!("Tracer is disabled");
 		}
 
-		Ok(Self { enabled })
+		Ok(Self {
+			enabled: config.enabled,
+		})
 	}
 
 	/// Flushes pending fastrace records if tracing was initialized.

--- a/nimbis-telemetry/src/tracer.rs
+++ b/nimbis-telemetry/src/tracer.rs
@@ -4,6 +4,7 @@ use fastrace::collector::Config;
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use opentelemetry::InstrumentationScope;
 use opentelemetry::KeyValue;
+use opentelemetry_otlp::Protocol;
 use opentelemetry_otlp::SpanExporter;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::Resource;
@@ -43,9 +44,9 @@ impl Tracer {
 			}
 
 			let protocol = match config.protocol.trim().to_ascii_lowercase().as_str() {
-				"grpc" => opentelemetry_otlp::Protocol::Grpc,
-				"http_binary" => opentelemetry_otlp::Protocol::HttpBinary,
-				"http_json" => opentelemetry_otlp::Protocol::HttpJson,
+				"grpc" => Protocol::Grpc,
+				"http_binary" => Protocol::HttpBinary,
+				"http_json" => Protocol::HttpJson,
 				invalid => {
 					return Err(TelemetryError::TraceInitFailed(format!(
 						"invalid trace protocol: {invalid}. expected grpc/http_binary/http_json"
@@ -53,8 +54,8 @@ impl Tracer {
 				}
 			};
 
-			let reporter = OpenTelemetryReporter::new(
-				SpanExporter::builder()
+			let exporter = match protocol {
+				Protocol::Grpc => SpanExporter::builder()
 					.with_tonic()
 					.with_endpoint(config.endpoint.clone())
 					.with_protocol(protocol)
@@ -62,7 +63,20 @@ impl Tracer {
 						config.export_timeout_seconds,
 					))
 					.build()
-					.expect("initialize otlp exporter"),
+					.map_err(|e| TelemetryError::TraceInitFailed(e.to_string()))?,
+				Protocol::HttpBinary | Protocol::HttpJson => SpanExporter::builder()
+					.with_http()
+					.with_endpoint(config.endpoint.clone())
+					.with_protocol(protocol)
+					.with_timeout(std::time::Duration::from_secs(
+						config.export_timeout_seconds,
+					))
+					.build()
+					.map_err(|e| TelemetryError::TraceInitFailed(e.to_string()))?,
+			};
+
+			let reporter = OpenTelemetryReporter::new(
+				exporter,
 				Cow::Owned(
 					Resource::builder()
 						.with_attributes([KeyValue::new("service.name", "nimbis")])
@@ -99,5 +113,25 @@ impl Tracer {
 		if self.enabled {
 			fastrace::flush();
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_init_rejects_invalid_trace_protocol() {
+		let config = TracerConfig {
+			enabled: true,
+			endpoint: "http://localhost:4317".into(),
+			sampling_ratio: 1.0,
+			protocol: "invalid".into(),
+			export_timeout_seconds: 10,
+			report_interval_ms: 1000,
+		};
+
+		let result = Tracer::init(config);
+		assert!(matches!(result, Err(TelemetryError::TraceInitFailed(_))));
 	}
 }

--- a/nimbis/src/config.rs
+++ b/nimbis/src/config.rs
@@ -78,6 +78,21 @@ pub enum ConfigError {
 	#[error("Invalid trace_endpoint: {0}. Expected an http or https URL with a host")]
 	InvalidTraceEndpoint(String),
 
+	#[error("Invalid trace_sampling_ratio: {0}. Expected a value between 0.0 and 1.0")]
+	InvalidTraceSamplingRatio(f64),
+
+	#[error("Invalid trace_protocol: {0}. Valid values: grpc, http_binary, http_json")]
+	InvalidTraceProtocol(String),
+
+	#[error("trace_export_timeout_seconds must be greater than 0")]
+	InvalidTraceExportTimeout,
+
+	#[error("trace_report_interval_ms must be greater than 0")]
+	InvalidTraceReportInterval,
+
+	#[error("Invalid environment variable {key}: {value}")]
+	InvalidEnvVar { key: String, value: String },
+
 	#[error(transparent)]
 	Telemetry(#[from] TelemetryError),
 }
@@ -107,6 +122,14 @@ pub struct ServerConfig {
 	#[online_config(immutable)]
 	pub trace_endpoint: String,
 	#[online_config(immutable)]
+	pub trace_sampling_ratio: f64,
+	#[online_config(immutable)]
+	pub trace_protocol: String,
+	#[online_config(immutable)]
+	pub trace_export_timeout_seconds: u64,
+	#[online_config(immutable)]
+	pub trace_report_interval_ms: u64,
+	#[online_config(immutable)]
 	pub worker_threads: usize,
 }
 
@@ -123,6 +146,29 @@ impl ServerConfig {
 
 		if self.trace_enabled {
 			validate_trace_endpoint(&self.trace_endpoint)?;
+		}
+
+		if !(0.0..=1.0).contains(&self.trace_sampling_ratio) {
+			return Err(ConfigError::InvalidTraceSamplingRatio(
+				self.trace_sampling_ratio,
+			));
+		}
+
+		match self.trace_protocol.trim().to_ascii_lowercase().as_str() {
+			"grpc" | "http_binary" | "http_json" => {}
+			_ => {
+				return Err(ConfigError::InvalidTraceProtocol(
+					self.trace_protocol.clone(),
+				));
+			}
+		}
+
+		if self.trace_export_timeout_seconds == 0 {
+			return Err(ConfigError::InvalidTraceExportTimeout);
+		}
+
+		if self.trace_report_interval_ms == 0 {
+			return Err(ConfigError::InvalidTraceReportInterval);
 		}
 
 		Ok(())
@@ -142,6 +188,10 @@ impl Default for ServerConfig {
 			log_rotation: "daily".into(),
 			trace_enabled: false,
 			trace_endpoint: "".into(),
+			trace_sampling_ratio: 0.0001,
+			trace_protocol: "grpc".into(),
+			trace_export_timeout_seconds: 10,
+			trace_report_interval_ms: 1000,
 			worker_threads: num_cpus::get(),
 		}
 	}
@@ -215,6 +265,8 @@ pub fn setup(args: Cli) -> Result<(), ConfigError> {
 		config.worker_threads = t;
 	}
 
+	apply_trace_env_overrides(&mut config)?;
+
 	config.validate()?;
 
 	let log_output = resolve_log_output(&config)?;
@@ -229,12 +281,67 @@ pub fn setup(args: Cli) -> Result<(), ConfigError> {
 	let telemetry_manager = Arc::new(TelemetryManager::init(
 		&config.log_level,
 		log_output,
-		config.trace_enabled,
-		config.trace_endpoint.clone(),
+		nimbis_telemetry::tracer::TracerConfig {
+			enabled: config.trace_enabled,
+			endpoint: config.trace_endpoint.clone(),
+			sampling_ratio: config.trace_sampling_ratio,
+			protocol: config.trace_protocol.clone(),
+			export_timeout_seconds: config.trace_export_timeout_seconds,
+			report_interval_ms: config.trace_report_interval_ms,
+		},
 	)?);
 	TELEMETRY_MANAGER.init(telemetry_manager);
 	SERVER_CONF.init(config);
 	Ok(())
+}
+
+fn apply_trace_env_overrides(config: &mut ServerConfig) -> Result<(), ConfigError> {
+	if let Some(raw) = read_non_empty_env("NIMBIS_TRACE_ENABLED") {
+		config.trace_enabled = raw
+			.parse::<bool>()
+			.map_err(|_| ConfigError::InvalidEnvVar {
+				key: "NIMBIS_TRACE_ENABLED".into(),
+				value: raw.clone(),
+			})?;
+	}
+
+	if let Some(endpoint) = read_non_empty_env("NIMBIS_TRACE_ENDPOINT") {
+		config.trace_endpoint = endpoint;
+	}
+
+	if let Some(raw) = read_non_empty_env("NIMBIS_TRACE_SAMPLING_RATIO") {
+		config.trace_sampling_ratio =
+			raw.parse::<f64>().map_err(|_| ConfigError::InvalidEnvVar {
+				key: "NIMBIS_TRACE_SAMPLING_RATIO".into(),
+				value: raw.clone(),
+			})?;
+	}
+
+	if let Some(protocol) = read_non_empty_env("NIMBIS_TRACE_PROTOCOL") {
+		config.trace_protocol = protocol;
+	}
+
+	if let Some(raw) = read_non_empty_env("NIMBIS_TRACE_EXPORT_TIMEOUT_SECONDS") {
+		config.trace_export_timeout_seconds =
+			raw.parse::<u64>().map_err(|_| ConfigError::InvalidEnvVar {
+				key: "NIMBIS_TRACE_EXPORT_TIMEOUT_SECONDS".into(),
+				value: raw.clone(),
+			})?;
+	}
+
+	if let Some(raw) = read_non_empty_env("NIMBIS_TRACE_REPORT_INTERVAL_MS") {
+		config.trace_report_interval_ms =
+			raw.parse::<u64>().map_err(|_| ConfigError::InvalidEnvVar {
+				key: "NIMBIS_TRACE_REPORT_INTERVAL_MS".into(),
+				value: raw.clone(),
+			})?;
+	}
+
+	Ok(())
+}
+
+fn read_non_empty_env(key: &str) -> Option<String> {
+	std::env::var(key).ok().filter(|v| !v.trim().is_empty())
 }
 
 fn resolve_default_config_path_from_base(base: &Path) -> Option<PathBuf> {
@@ -436,6 +543,35 @@ worker_threads: 4
 	#[test]
 	fn test_default_trace_enabled() {
 		assert!(!ServerConfig::default().trace_enabled);
+	}
+
+	#[test]
+	fn test_default_trace_sampling_ratio() {
+		assert_eq!(ServerConfig::default().trace_sampling_ratio, 0.0001);
+	}
+
+	#[rstest]
+	#[case(-0.1)]
+	#[case(1.1)]
+	fn test_trace_sampling_ratio_must_be_between_zero_and_one(#[case] ratio: f64) {
+		let config = ServerConfig {
+			trace_sampling_ratio: ratio,
+			..ServerConfig::default()
+		};
+
+		let err = config.validate().unwrap_err();
+		assert!(matches!(err, ConfigError::InvalidTraceSamplingRatio(_)));
+	}
+
+	#[test]
+	fn test_trace_protocol_rejects_unknown_values() {
+		let config = ServerConfig {
+			trace_protocol: "udp".into(),
+			..ServerConfig::default()
+		};
+
+		let err = config.validate().unwrap_err();
+		assert!(matches!(err, ConfigError::InvalidTraceProtocol(_)));
 	}
 
 	#[test]

--- a/nimbis/src/worker.rs
+++ b/nimbis/src/worker.rs
@@ -20,6 +20,7 @@ use crate::client::ClientConnection;
 use crate::client::next_client_session_id;
 use crate::cmd::CmdContext;
 use crate::cmd::CmdTable;
+use crate::server_config;
 
 pub struct CmdRequest {
 	pub(crate) cmd_name: String,
@@ -105,13 +106,19 @@ impl Worker {
 	}
 
 	async fn handle_cmd_request(req: CmdRequest, cmd_table: &CmdTable, storage: &Storage) {
+		if !server_config!(trace_enabled) {
+			Self::handle_cmd_request_inner(req, cmd_table, storage).await;
+			return;
+		}
+
 		// Apply a 0.01% sampling rate for tracing to prevent massive gRPC payload and
 		// reduce overhead.
+		let sampling_ratio = server_config!(trace_sampling_ratio);
 		let is_sampled = std::time::SystemTime::now()
 			.duration_since(std::time::UNIX_EPOCH)
 			.unwrap_or_default()
 			.subsec_nanos()
-			.is_multiple_of(10000);
+			.is_multiple_of(sampling_divisor(sampling_ratio));
 		let span_context = SpanContext::random().sampled(is_sampled);
 		let root_span = Span::root(fastrace::func_path!(), span_context).with_properties(|| {
 			[
@@ -140,5 +147,30 @@ impl Worker {
 				req.cmd_name, resp
 			);
 		}
+	}
+}
+
+fn sampling_divisor(sampling_ratio: f64) -> u32 {
+	if sampling_ratio >= 1.0 {
+		return 1;
+	}
+
+	if sampling_ratio <= 0.0 {
+		return u32::MAX;
+	}
+
+	(1.0 / sampling_ratio).round().max(1.0) as u32
+}
+
+#[cfg(test)]
+mod tests {
+	use super::sampling_divisor;
+
+	#[test]
+	fn test_sampling_divisor_limits() {
+		assert_eq!(sampling_divisor(1.0), 1);
+		assert_eq!(sampling_divisor(0.5), 2);
+		assert_eq!(sampling_divisor(0.0001), 10000);
+		assert_eq!(sampling_divisor(0.0), u32::MAX);
 	}
 }

--- a/nimbis/tests/mock/mock_server.rs
+++ b/nimbis/tests/mock/mock_server.rs
@@ -38,6 +38,10 @@ impl MockNimbisServer {
 			log_rotation: "daily".to_string(),
 			trace_enabled: false,
 			trace_endpoint: "".to_string(),
+			trace_sampling_ratio: 0.0001,
+			trace_protocol: "grpc".to_string(),
+			trace_export_timeout_seconds: 10,
+			trace_report_interval_ms: 1000,
 			worker_threads: 2,
 		};
 


### PR DESCRIPTION
### Motivation

- Make telemetry/tracing behavior controllable for production deployments instead of relying on hardcoded defaults.  
- Provide startup-only knobs and environment overrides so operators can tune sampling, protocol and exporter settings without code changes.  
- Reduce operational risk and cost by allowing safe low-rate sampling and fast disable paths under load.

### Description

- Added startup-only tracing fields to `ServerConfig`: `trace_sampling_ratio`, `trace_protocol`, `trace_export_timeout_seconds`, and `trace_report_interval_ms`, and included validation and defaults in `nimbis/src/config.rs`.  
- Introduced environment variable overrides (`NIMBIS_TRACE_*`) applied at startup via `apply_trace_env_overrides` so deployment-time changes can be made without editing files.  
- Reworked telemetry initialization to pass a structured `TracerConfig` into the telemetry crate and plumb those values through `nimbis-telemetry` (`TracerConfig` struct in `nimbis-telemetry/src/tracer.rs` and `manager.rs`).  
- Made worker tracing conditional and sampling-driven: when tracing is disabled the worker takes a fast path, otherwise sampling uses `trace_sampling_ratio` (replacing the former hard-coded 0.01% logic) and added `sampling_divisor` helper in `nimbis/src/worker.rs`.  
- Updated `config/config_template.toml` and `docs/config.md` to document new fields, env overrides and recommended profiles.

### Testing

- Ran `cargo fmt --all` successfully.  
- Ran unit tests relevant to the changes and they passed: `config::tests::test_default_trace_sampling_ratio`, `config::tests::test_trace_sampling_ratio_must_be_between_zero_and_one` (both cases), `config::tests::test_trace_protocol_rejects_unknown_values`, and `worker::tests::test_sampling_divisor_limits`.  
- Performed `cargo check -p nimbis -p nimbis-telemetry` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06debd40483338af8fcb13a10642c)