### PR TITLE
Fix benchmark CI to build main from source and use a single runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,8 @@ jobs:
 
     - name: Run Main benchmark
       run: |
-        ./artifacts/main/target/release/nimbis &
+        NIMBIS_OBJECT_STORE_URL=file:nimbis_benchmark_store/main \
+          ./artifacts/main/target/release/nimbis &
         NIMBIS_PID=$!
         trap 'kill $NIMBIS_PID >/dev/null 2>&1 || true' EXIT
         echo "Nimbis (Main) started with PID $NIMBIS_PID"
@@ -472,7 +473,8 @@ jobs:
 
     - name: Run Main benchmark with pipeline
       run: |
-        ./artifacts/main/target/release/nimbis &
+        NIMBIS_OBJECT_STORE_URL=file:nimbis_benchmark_store/main-pipeline \
+          ./artifacts/main/target/release/nimbis &
         NIMBIS_PID=$!
         trap 'kill $NIMBIS_PID >/dev/null 2>&1 || true' EXIT
         echo "Nimbis (Main) started with PID $NIMBIS_PID"
@@ -485,7 +487,8 @@ jobs:
 
     - name: Run PR benchmark
       run: |
-        ./artifacts/pr/target/release/nimbis &
+        NIMBIS_OBJECT_STORE_URL=file:nimbis_benchmark_store/pr \
+          ./artifacts/pr/target/release/nimbis &
         NIMBIS_PID=$!
         trap 'kill $NIMBIS_PID >/dev/null 2>&1 || true' EXIT
         echo "Nimbis (PR) started with PID $NIMBIS_PID"
@@ -498,7 +501,8 @@ jobs:
 
     - name: Run PR benchmark with pipeline
       run: |
-        ./artifacts/pr/target/release/nimbis &
+        NIMBIS_OBJECT_STORE_URL=file:nimbis_benchmark_store/pr-pipeline \
+          ./artifacts/pr/target/release/nimbis &
         NIMBIS_PID=$!
         trap 'kill $NIMBIS_PID >/dev/null 2>&1 || true' EXIT
         echo "Nimbis (PR) started with PID $NIMBIS_PID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,40 @@ jobs:
         path: target/release/nimbis.exe
         if-no-files-found: error
 
+  build_main_release:
+    name: Build Main Release
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+
+    - name: Setup Rust Toolchain
+      uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: llvm-tools-preview
+
+    - name: Cache Rust Dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ubuntu-latest-rust-build-main-release
+        cache-on-failure: true
+
+    - name: Install just
+      uses: taiki-e/install-action@just
+
+    - name: Build Release
+      run: just build --release
+
+    - name: Upload Main Release Binary
+      uses: actions/upload-artifact@v7
+      with:
+        name: nimbis-release-main-ubuntu-latest
+        path: target/release/nimbis
+        if-no-files-found: error
+
   e2e_local:
     name: E2E Test (Local Filesystem)
     needs: build_release
@@ -242,7 +276,7 @@ jobs:
   benchmark:
     name: Benchmark (${{ matrix.slot_title }}, ${{ matrix.data_size }} bytes)
     if: ${{ github.event_name == 'pull_request' }}
-    needs: build_release
+    needs: [build_release, build_main_release]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -284,35 +318,10 @@ jobs:
         shared-key: benchmark-xtask
         cache-on-failure: true
 
-    - name: Resolve main benchmark baseline run
-      id: resolve-main-run
-      uses: actions/github-script@v9
-      with:
-        script: |
-          const runs = await github.rest.actions.listWorkflowRuns({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: 'ci.yml',
-            branch: 'main',
-            event: 'push',
-            status: 'completed',
-            per_page: 20,
-          });
-
-          const run = runs.data.workflow_runs.find((entry) => entry.conclusion === 'success');
-          if (!run) {
-            throw new Error('Could not find a successful CI workflow run on main.');
-          }
-
-          core.setOutput('run_id', String(run.id));
-
-    - name: Download main ubuntu release artifact
+    - name: Download main benchmark binary
       uses: actions/download-artifact@v8
       with:
-        github-token: ${{ github.token }}
-        repository: ${{ github.repository }}
-        run-id: ${{ steps.resolve-main-run.outputs.run_id }}
-        name: nimbis-release-ubuntu-latest
+        name: nimbis-release-main-ubuntu-latest
         path: artifacts/main/target/release
 
     - name: Download PR ubuntu release artifact
@@ -472,16 +481,10 @@ jobs:
         echo "Nimbis (Main) started with PID $NIMBIS_PID"
         sleep 10
 
-        redis-cli FLUSHDB || true
-        redis-cli HSET bench:hash field1 value1 || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 SADD bench:set:srem member:__rand_int__ > /dev/null || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 ZADD bench:zset:zrem __rand_int__ member:__rand_int__ > /dev/null || true
-
         echo "Running Benchmark on Main..."
-        redis-benchmark -q -t set,get,hset,lpush,lpop,sadd,zadd -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} > benchmark_main.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} HGET bench:hash field1 >> benchmark_main.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} SREM bench:set:srem member:__rand_int__ >> benchmark_main.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} ZREM bench:zset:zrem member:__rand_int__ >> benchmark_main.txt || true
+        N=500000 C=100 R=100000 D=${{ matrix.data_size }} P=1 OUTPUT_DIR=benchmark_main_suites \
+          cargo xtask redis-benchmark --profile comparison \
+          > benchmark_main.txt
 
     - name: Run Main benchmark with pipeline
       run: |
@@ -491,16 +494,10 @@ jobs:
         echo "Nimbis (Main) started with PID $NIMBIS_PID"
         sleep 10
 
-        redis-cli FLUSHDB || true
-        redis-cli HSET bench:hash field1 value1 || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 SADD bench:set:srem member:__rand_int__ > /dev/null || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 ZADD bench:zset:zrem __rand_int__ member:__rand_int__ > /dev/null || true
-
         echo "Running Benchmark on Main (Pipeline)..."
-        redis-benchmark -q -t set,get,hset,lpush,lpop,sadd,zadd -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} -P 50 > benchmark_main_pipeline.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} -P 50 HGET bench:hash field1 >> benchmark_main_pipeline.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} -P 50 SREM bench:set:srem member:__rand_int__ >> benchmark_main_pipeline.txt || true
-        redis-benchmark -q -n 500000 -c 100 -r 100000 -d ${{ matrix.data_size }} -P 50 ZREM bench:zset:zrem member:__rand_int__ >> benchmark_main_pipeline.txt || true
+        N=500000 C=100 R=100000 D=${{ matrix.data_size }} P=50 OUTPUT_DIR=benchmark_main_pipeline_suites \
+          cargo xtask redis-benchmark --profile comparison \
+          > benchmark_main_pipeline.txt
 
     - name: Run PR benchmark
       run: |


### PR DESCRIPTION
## Summary
- Build the main benchmark binary from the PR base SHA inside the workflow instead of downloading a historical `main` artifact
- Keep Main and PR benchmarks on the same `cargo xtask redis-benchmark --profile comparison` path
- Remove the stale main-run lookup so benchmark comparisons come from a fresh, comparable baseline

## Testing
- `just check` passed
- YAML workflow validation passed
- Workflow-level invariant checks confirmed the benchmark job now uses the fresh main build and the shared xtask runner