### PR TITLE
fix: align command docs, benchmark profiles, and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,51 @@
+# Roadmap
+
+Nimbis is an early-stage Redis-compatible database backed by object storage.
+The near-term roadmap prioritizes a correct, documented Redis subset before
+expanding command breadth.
+
+## Current Baseline
+
+- Server command registration lives in `nimbis/src/cmd/table.rs`.
+- The implemented command list is documented in `docs/commands.md`.
+- Redis benchmark coverage is documented in `docs/redis-benchmark.md` and
+  implemented in `xtask/src/redis_benchmark.rs`.
+- Object-storage persistence is built on SlateDB-compatible storage.
+- Go end-to-end tests cover Redis protocol behavior across the server boundary.
+
+## P0: Fact Alignment And Benchmark Coherence
+
+- Keep `docs/commands.md`, `docs/redis-benchmark.md`, and
+  `xtask/src/redis_benchmark.rs` aligned with the command table.
+- Keep the `full` redis-benchmark profile limited to currently implemented
+  commands. `FLUSHDB` is setup/cleanup only, not a throughput benchmark.
+- Keep the `comparison` redis-benchmark profile on a stable subset that can be
+  compared between PR and main branch builds.
+- Do not list unsupported commands such as `MGET`, `MSET`, `SUNION`, `SINTER`,
+  or `SDIFF` as supported, and do not benchmark them until they are
+  implemented.
+
+## P1: Redis-Compatible Command Depth
+
+- Add high-value Redis command options where they fit Nimbis semantics, starting
+  with string command options such as `SET` modifiers.
+- Expand multi-key string support only when worker routing and storage
+  semantics are explicit.
+- Add set algebra commands after storage behavior and benchmark coverage are
+  defined.
+- Keep compatibility notes up to date for intentional gaps.
+
+## P2: Persistence And Recovery Confidence
+
+- Strengthen persistence tests around object-store-backed startup, restart, and
+  recovery paths.
+- Document operational expectations for supported object storage backends.
+- Keep storage benchmarks focused on performance-sensitive paths.
+
+## P3: Operational Readiness
+
+- Improve configuration documentation as runtime and bootstrap-only settings
+  evolve.
+- Preserve structured logging and telemetry lifecycle ownership.
+- Keep CI checks focused on code quality, command compatibility, and benchmark
+  signal.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -97,12 +97,24 @@ Source of truth: `nimbis/src/cmd/table.rs`.
   - `CLIENT GETNAME`
   - `CLIENT LIST`
 
+## Benchmark Alignment
+
+The `full` redis-benchmark profile in `xtask/src/redis_benchmark.rs` should
+cover this implemented command table. `FLUSHDB` is the exception: it is used for
+benchmark setup and cleanup, not throughput comparison.
+
+The `comparison` redis-benchmark profile is intentionally smaller so CI can
+compare PR and main branch performance across a stable command subset. It must
+still contain only commands listed in this document.
+
 ## Add a New Command
 
 1. Add `cmd_xxx.rs` under `nimbis/src/cmd/`.
 2. Implement `Cmd` for the command struct.
 3. Export the module in `nimbis/src/cmd/mod.rs`.
 4. Register it in `nimbis/src/cmd/table.rs`.
+5. Update this document, `docs/redis-benchmark.md`, and the benchmark profiles
+   in `xtask/src/redis_benchmark.rs` together.
 
 ## Redis Compatibility Notes (Known Gaps)
 
@@ -114,5 +126,5 @@ Nimbis is Redis-compatible for the implemented subset, but does **not** yet impl
 - `CLIENT` is limited to `ID`, `SETNAME`, `GETNAME`, and `LIST`.
 - Multi-key string helpers like `MGET`/`MSET`, transactions (`MULTI`/`EXEC`), pub/sub, scripting, streams, cluster commands, and ACL are not documented as implemented in this command table.
 
-When adding new commands or options, update both `nimbis/src/cmd/table.rs` and this document together.
-
+When adding new commands or options, update `nimbis/src/cmd/table.rs`, this
+document, and the benchmark documentation/profile lists together.

--- a/docs/redis-benchmark.md
+++ b/docs/redis-benchmark.md
@@ -82,10 +82,11 @@ cargo xtask redis-benchmark --n 10000 --c 100 --p 16 --threads 4
 Extra arguments for `redis-benchmark` can be passed after `--` and are forwarded
 to every benchmark invocation.
 
-The default command profile is `full`, which covers all Nimbis-supported
-commands listed below. Benchmark CI uses `--profile comparison` for the
-main-vs-PR comparison so the main branch can be benchmarked before it has newly
-added commands from a PR.
+The default command profile is `full`, which covers the currently implemented
+Nimbis command table from [Commands](commands.md). `FLUSHDB` is used only for
+setup and cleanup isolation, not as a throughput benchmark. Benchmark CI uses
+`--profile comparison` for the main-vs-PR comparison so the main branch can be
+benchmarked before it has newly added commands from a PR.
 
 ## Built-In Coverage
 
@@ -106,7 +107,6 @@ Built-in Redis tests enabled for Nimbis:
 - `sadd`
 - `hset`
 - `zadd`
-- `mset`
 
 Built-in Redis tests skipped because Nimbis does not currently implement the
 commands:
@@ -115,10 +115,10 @@ commands:
 - `zpopmin`
 - `xadd`
 
-Redis `LRANGE` built-ins are skipped from the default Nimbis benchmark because
-current LRANGE performance needs separate optimization work, and
+Redis `LRANGE` built-ins are skipped from the Nimbis benchmark because
 `redis-benchmark -t lrange` expands into the larger `LRANGE_300`,
-`LRANGE_500`, and `LRANGE_600` cases.
+`LRANGE_500`, and `LRANGE_600` cases. The `full` profile covers Nimbis
+`LRANGE` with a direct custom command instead.
 
 - `lrange`
 - `lrange_100`
@@ -133,16 +133,21 @@ directly to `redis-benchmark`.
 
 Covered command groups:
 
-- String/generic: `DEL`, `EXISTS`, `DECR`, `APPEND`, `MGET`, `MSETNX`
+- String/generic: `DEL`, `EXISTS`, `DECR`, `APPEND`
 - Hash: `HDEL`, `HGET`, `HLEN`, `HMGET`, `HGETALL`
-- List: `LLEN`
-- Set: `SMEMBERS`, `SUNION`, `SINTER`, `SDIFF`, `SISMEMBER`, `SREM`, `SCARD`
+- List: `LLEN`, `LRANGE`
+- Set: `SMEMBERS`, `SISMEMBER`, `SREM`, `SCARD`
 - Sorted set: `ZRANGE`, `ZSCORE`, `ZREM`, `ZCARD`
 - TTL: `EXPIRE`, `TTL`
 - Control smoke: `HELLO 2`, `CONFIG GET *`, `CLIENT ID`
 
 `FLUSHDB` is used only for setup and cleanup isolation. It is not included in
 throughput comparisons.
+
+The `comparison` profile is intentionally smaller than `full`. It benchmarks:
+
+- Built-in tests: `set`, `get`, `hset`, `lpush`, `lpop`, `sadd`, `zadd`
+- Custom commands: `HGET`, `SREM`, `ZREM`
 
 ## Notes
 

--- a/xtask/src/redis_benchmark.rs
+++ b/xtask/src/redis_benchmark.rs
@@ -13,7 +13,7 @@ use clap::ValueEnum;
 
 use crate::write_stdout_line;
 
-const BUILTIN_SUPPORTED: &str = "ping,set,get,incr,lpush,rpush,lpop,rpop,sadd,hset,zadd,mset";
+const BUILTIN_SUPPORTED: &str = "ping,set,get,incr,lpush,rpush,lpop,rpop,sadd,hset,zadd";
 
 #[derive(ClapArgs, Debug, Default)]
 pub struct Args {
@@ -398,25 +398,6 @@ fn run_custom_suite<R: Runner>(config: &Config, runner: &R) -> Result<(), String
 			"append",
 			&["APPEND", "bench:string:append:__rand_int__", "value"],
 		),
-		(
-			"mget_multi_key",
-			&[
-				"MGET",
-				"bench:string:a:__rand_int__",
-				"bench:string:b:__rand_int__",
-				"bench:string:missing:__rand_int__",
-			],
-		),
-		(
-			"msetnx_multi_key",
-			&[
-				"MSETNX",
-				"bench:string:msetnx:a:__rand_int__",
-				"value-a",
-				"bench:string:msetnx:b:__rand_int__",
-				"value-b",
-			],
-		),
 		("hdel", &["HDEL", "bench:hash:hdel", "field:__rand_int__"]),
 		("hget", &["HGET", "bench:hash", "field1"]),
 		("hlen", &["HLEN", "bench:hash"]),
@@ -426,10 +407,8 @@ fn run_custom_suite<R: Runner>(config: &Config, runner: &R) -> Result<(), String
 		),
 		("hgetall", &["HGETALL", "bench:hash"]),
 		("llen", &["LLEN", "bench:list"]),
+		("lrange", &["LRANGE", "bench:list", "0", "-1"]),
 		("smembers", &["SMEMBERS", "bench:set:a"]),
-		("sunion", &["SUNION", "bench:set:a", "bench:set:b"]),
-		("sinter", &["SINTER", "bench:set:a", "bench:set:b"]),
-		("sdiff", &["SDIFF", "bench:set:a", "bench:set:b"]),
 		("sismember", &["SISMEMBER", "bench:set:a", "a"]),
 		("srem", &["SREM", "bench:set:srem", "member:__rand_int__"]),
 		("scard", &["SCARD", "bench:set:a"]),
@@ -678,6 +657,7 @@ fn env_bool(env_name: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use std::cell::RefCell;
+	use std::collections::BTreeSet;
 	use std::path::Path;
 	use std::path::PathBuf;
 
@@ -698,6 +678,48 @@ mod tests {
 		streaming_calls: RefCell<Vec<RecordedCall>>,
 	}
 
+	const BENCHMARKED_FULL_PROFILE_COMMANDS: &[&str] = &[
+		"APPEND",
+		"CLIENT",
+		"CONFIG",
+		"DECR",
+		"DEL",
+		"EXISTS",
+		"EXPIRE",
+		"GET",
+		"HELLO",
+		"HDEL",
+		"HGET",
+		"HGETALL",
+		"HLEN",
+		"HMGET",
+		"HSET",
+		"INCR",
+		"LLEN",
+		"LPOP",
+		"LPUSH",
+		"LRANGE",
+		"PING",
+		"RPOP",
+		"RPUSH",
+		"SADD",
+		"SCARD",
+		"SET",
+		"SISMEMBER",
+		"SMEMBERS",
+		"SREM",
+		"TTL",
+		"ZADD",
+		"ZCARD",
+		"ZRANGE",
+		"ZREM",
+		"ZSCORE",
+	];
+
+	const BENCHMARKED_COMPARISON_PROFILE_COMMANDS: &[&str] = &[
+		"GET", "HGET", "HSET", "LPOP", "LPUSH", "SADD", "SET", "SREM", "ZADD", "ZREM",
+	];
+
 	impl FakeRunner {
 		fn streamed_labels(&self) -> Vec<String> {
 			self.streaming_calls
@@ -717,6 +739,14 @@ mod tests {
 				.collect()
 		}
 
+		fn streamed_commands(&self) -> BTreeSet<String> {
+			self.streaming_calls
+				.borrow()
+				.iter()
+				.flat_map(|call| benchmarked_commands(&call.args))
+				.collect()
+		}
+
 		fn status_commands(&self, program: &str) -> Vec<Vec<String>> {
 			self.status_calls
 				.borrow()
@@ -725,6 +755,31 @@ mod tests {
 				.map(|call| call.args.clone())
 				.collect()
 		}
+	}
+
+	fn benchmarked_commands(args: &[String]) -> Vec<String> {
+		if let Some(index) = args.iter().position(|arg| arg == "-t") {
+			return args
+				.get(index + 1)
+				.into_iter()
+				.flat_map(|commands| commands.split(','))
+				.map(|command| command.to_ascii_uppercase())
+				.collect();
+		}
+
+		let known_commands = benchmarked_command_set(BENCHMARKED_FULL_PROFILE_COMMANDS);
+		args.iter()
+			.find(|arg| known_commands.contains(arg.as_str()))
+			.into_iter()
+			.cloned()
+			.collect()
+	}
+
+	fn benchmarked_command_set(commands: &[&str]) -> BTreeSet<String> {
+		commands
+			.iter()
+			.map(|command| (*command).to_string())
+			.collect()
 	}
 
 	impl Runner for FakeRunner {
@@ -867,10 +922,14 @@ mod tests {
 		let labels = runner.streamed_labels();
 		assert!(labels.contains(&"builtin_supported".to_string()));
 		assert!(labels.contains(&"del_multi_key".to_string()));
-		assert!(labels.contains(&"msetnx_multi_key".to_string()));
+		assert!(labels.contains(&"lrange".to_string()));
 		assert!(labels.contains(&"hello_2".to_string()));
 		assert!(labels.contains(&"client_id".to_string()));
-		assert_eq!(labels.len(), 29);
+		assert_eq!(labels.len(), 25);
+		assert_eq!(
+			runner.streamed_commands(),
+			benchmarked_command_set(BENCHMARKED_FULL_PROFILE_COMMANDS)
+		);
 
 		let redis_cli_calls = runner.status_commands("/bin/echo");
 		assert!(
@@ -920,6 +979,10 @@ mod tests {
 				"srem".to_string(),
 				"zrem".to_string(),
 			]
+		);
+		assert_eq!(
+			runner.streamed_commands(),
+			benchmarked_command_set(BENCHMARKED_COMPARISON_PROFILE_COMMANDS)
 		);
 		assert!(!config.output_dir.join("hello_2.txt").exists());
 	}


### PR DESCRIPTION
## Summary
- Added `ROADMAP.md` to define the near-term fact-alignment and benchmark-coherence priorities.
- Updated `docs/commands.md` and `docs/redis-benchmark.md` so the supported command list and benchmark coverage match the implemented command table.
- Trimmed `xtask/src/redis_benchmark.rs` to remove unsupported benchmark commands and added coverage for `LRANGE` in the full profile.
- Added tests to lock the full and comparison benchmark profile command sets.

## Testing
- `cargo test -p xtask redis_benchmark`
- `just check`