### PR TITLE
Add a storage_lock attribute macro for storage entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,6 +1782,7 @@ dependencies = [
  "quote",
  "rstest",
  "syn 2.0.117",
+ "tokio",
 ]
 
 [[package]]
@@ -1806,6 +1807,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
+ "nimbis-macros",
  "rstest",
  "slatedb",
  "thiserror 2.0.18",

--- a/nimbis-macros/Cargo.toml
+++ b/nimbis-macros/Cargo.toml
@@ -17,3 +17,4 @@ syn = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tokio = { workspace = true }

--- a/nimbis-macros/src/lib.rs
+++ b/nimbis-macros/src/lib.rs
@@ -5,7 +5,109 @@ use syn::Data;
 use syn::DeriveInput;
 use syn::Error;
 use syn::Fields;
+use syn::FnArg;
+use syn::Ident;
+use syn::ItemFn;
+use syn::Result;
+use syn::Token;
+use syn::parse::Parse;
+use syn::parse::ParseStream;
 use syn::parse_macro_input;
+
+struct StorageLockArgs {
+	mode: Ident,
+	key: Option<Ident>,
+}
+
+impl Parse for StorageLockArgs {
+	fn parse(input: ParseStream<'_>) -> Result<Self> {
+		let mode = input.parse()?;
+		let key = if input.peek(Token![,]) {
+			input.parse::<Token![,]>()?;
+			Some(input.parse()?)
+		} else {
+			None
+		};
+
+		if !input.is_empty() {
+			return Err(input.error(
+				"unsupported storage_lock arguments; expected `read, key`, `write, key`, `read_many, keys`, `write_many, keys`, or `global_write`",
+			));
+		}
+
+		Ok(Self { mode, key })
+	}
+}
+
+#[proc_macro_attribute]
+pub fn storage_lock(attr: TokenStream, item: TokenStream) -> TokenStream {
+	let args = parse_macro_input!(attr as StorageLockArgs);
+	let input = parse_macro_input!(item as ItemFn);
+
+	if input.sig.asyncness.is_none() {
+		return Error::new_spanned(input.sig.fn_token, "storage_lock only supports async fn")
+			.to_compile_error()
+			.into();
+	}
+
+	if !matches!(input.sig.inputs.first(), Some(FnArg::Receiver(_))) {
+		return Error::new_spanned(input.sig.ident, "storage_lock requires a method with self")
+			.to_compile_error()
+			.into();
+	}
+
+	let mode = args.mode.to_string();
+	let lock = match (mode.as_str(), args.key) {
+		("read", Some(key)) => quote! {
+			let _guard = self.read_lock([#key.clone()]).await;
+		},
+		("write", Some(key)) => quote! {
+			let _guard = self.write_lock([#key.clone()]).await;
+		},
+		("read_many", Some(keys)) => quote! {
+			let #keys: Vec<_> = #keys.into_iter().collect();
+			let _guard = self.read_lock(#keys.clone()).await;
+		},
+		("write_many", Some(keys)) => quote! {
+			let #keys: Vec<_> = #keys.into_iter().collect();
+			let _guard = self.write_lock(#keys.clone()).await;
+		},
+		("global_write", None) => quote! {
+			let _guard = self.global_write_lock().await;
+		},
+		("global_write", Some(key)) => {
+			return Error::new_spanned(key, "global_write storage_lock does not take a key")
+				.to_compile_error()
+				.into();
+		}
+		("read" | "write" | "read_many" | "write_many", None) => {
+			return Error::new_spanned(args.mode, "storage_lock mode requires a key argument")
+				.to_compile_error()
+				.into();
+		}
+		_ => {
+			return Error::new_spanned(
+				args.mode,
+				"unsupported storage_lock mode; expected `read`, `write`, `read_many`, `write_many`, or `global_write`",
+			)
+			.to_compile_error()
+			.into();
+		}
+	};
+
+	let attrs = input.attrs;
+	let vis = input.vis;
+	let sig = input.sig;
+	let block = input.block;
+
+	TokenStream::from(quote! {
+		#(#attrs)*
+		#vis #sig {
+			#lock
+			#block
+		}
+	})
+}
 
 #[proc_macro_derive(OnlineConfig, attributes(online_config))]
 pub fn online_config_derive(input: TokenStream) -> TokenStream {

--- a/nimbis-macros/src/lib.rs
+++ b/nimbis-macros/src/lib.rs
@@ -66,11 +66,11 @@ pub fn storage_lock(attr: TokenStream, item: TokenStream) -> TokenStream {
 		},
 		("read_many", Some(keys)) => quote! {
 			let #keys: Vec<_> = #keys.into_iter().collect();
-			let _guard = self.read_lock(#keys.clone()).await;
+			let _guard = self.read_lock(#keys.iter().cloned()).await;
 		},
 		("write_many", Some(keys)) => quote! {
 			let #keys: Vec<_> = #keys.into_iter().collect();
-			let _guard = self.write_lock(#keys.clone()).await;
+			let _guard = self.write_lock(#keys.iter().cloned()).await;
 		},
 		("global_write", None) => quote! {
 			let _guard = self.global_write_lock().await;

--- a/nimbis-macros/tests/test_storage_lock.rs
+++ b/nimbis-macros/tests/test_storage_lock.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use nimbis_macros::storage_lock;
+
+#[derive(Clone, Default)]
+struct TestStorage {
+	events: Arc<Mutex<Vec<String>>>,
+}
+
+struct TestGuard {
+	events: Arc<Mutex<Vec<String>>>,
+}
+
+impl Drop for TestGuard {
+	fn drop(&mut self) {
+		self.events.lock().unwrap().push("drop".to_string());
+	}
+}
+
+impl TestStorage {
+	async fn read_lock(&self, keys: impl IntoIterator<Item = String>) -> TestGuard {
+		let keys = keys.into_iter().collect::<Vec<_>>().join(",");
+		self.events.lock().unwrap().push(format!("read:{keys}"));
+		TestGuard {
+			events: self.events.clone(),
+		}
+	}
+
+	async fn write_lock(&self, keys: impl IntoIterator<Item = String>) -> TestGuard {
+		let keys = keys.into_iter().collect::<Vec<_>>().join(",");
+		self.events.lock().unwrap().push(format!("write:{keys}"));
+		TestGuard {
+			events: self.events.clone(),
+		}
+	}
+
+	async fn global_write_lock(&self) -> TestGuard {
+		self.events.lock().unwrap().push("global_write".to_string());
+		TestGuard {
+			events: self.events.clone(),
+		}
+	}
+
+	#[storage_lock(read, key)]
+	async fn read_one(&self, key: String) -> usize {
+		self.events.lock().unwrap().push(format!("body:{key}"));
+		7
+	}
+
+	#[storage_lock(write_many, keys)]
+	async fn write_many<I>(&self, keys: I) -> usize
+	where
+		I: IntoIterator<Item = String>,
+	{
+		self.events
+			.lock()
+			.unwrap()
+			.push(format!("body:{}", keys.join(",")));
+		keys.len()
+	}
+
+	#[storage_lock(global_write)]
+	async fn global_write(&self) -> usize {
+		self.events.lock().unwrap().push("body".to_string());
+		3
+	}
+}
+
+#[tokio::test]
+async fn storage_lock_read_wraps_function_body() {
+	let storage = TestStorage::default();
+
+	let result = storage.read_one("alpha".to_string()).await;
+
+	assert_eq!(result, 7);
+	assert_eq!(
+		*storage.events.lock().unwrap(),
+		vec!["read:alpha", "body:alpha", "drop"],
+	);
+}
+
+#[tokio::test]
+async fn storage_lock_many_collects_keys_before_locking() {
+	let storage = TestStorage::default();
+
+	let result = storage
+		.write_many(["alpha".to_string(), "beta".to_string()])
+		.await;
+
+	assert_eq!(result, 2);
+	assert_eq!(
+		*storage.events.lock().unwrap(),
+		vec!["write:alpha,beta", "body:alpha,beta", "drop"],
+	);
+}
+
+#[tokio::test]
+async fn storage_lock_global_write_wraps_function_body() {
+	let storage = TestStorage::default();
+
+	let result = storage.global_write().await;
+
+	assert_eq!(result, 3);
+	assert_eq!(
+		*storage.events.lock().unwrap(),
+		vec!["global_write", "body", "drop"],
+	);
+}

--- a/nimbis-storage/Cargo.toml
+++ b/nimbis-storage/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { workspace = true }
 fastrace.workspace = true
 futures = { workspace = true }
 log = { workspace = true }
+nimbis-macros = { workspace = true }
 slatedb = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -411,7 +411,7 @@ mod tests {
 		assert_eq!(stored, vec![Bytes::from("old_member")]);
 
 		// DEL (Logical Delete - only Meta)
-		ctx.storage.del(key.clone()).await.unwrap();
+		ctx.storage.del([key.clone()]).await.unwrap();
 
 		// Verify empty
 		let exists = ctx.storage.exists(key.clone()).await.unwrap();
@@ -462,8 +462,8 @@ mod tests {
 		assert_eq!(stored.len(), 10);
 
 		// DEL: Logical delete (O(1) - only meta is removed)
-		let deleted = ctx.storage.del(key.clone()).await.unwrap();
-		assert!(deleted, "DEL should succeed");
+		let deleted = ctx.storage.del([key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1, "DEL should delete one key");
 
 		// Verify logically empty
 		let exists = ctx.storage.exists(key.clone()).await.unwrap();

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use nimbis_macros::storage_lock;
 use slatedb::Db;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
@@ -251,10 +252,9 @@ impl Storage {
 		Ok(())
 	}
 
+	#[storage_lock(global_write)]
 	#[fastrace::trace]
 	pub async fn flush_all(&self) -> Result<(), StorageError> {
-		let _guard = self.global_write_lock().await;
-
 		// Iterate over all DBs and delete all keys
 		// Since we don't have atomic flush_all, we do best effort sequential
 		// Scanning and deleting everything is slow but correct for tests.

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -413,8 +413,8 @@ mod tests {
 			.unwrap();
 		assert_eq!(created, 1);
 
-		let deleted = storage.del(key.clone()).await.unwrap();
-		assert!(deleted);
+		let deleted = storage.del([key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
 
 		let recreated = storage
 			.hset(key.clone(), field.clone(), Bytes::from("v2"))

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -1,6 +1,7 @@
 use bytes::Buf;
 use bytes::Bytes;
 use futures::future;
+use nimbis_macros::storage_lock;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
 
@@ -12,9 +13,9 @@ use crate::string::meta::MetaKey;
 use crate::utils::user_key_prefix;
 
 impl Storage {
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn hset(&self, key: Bytes, field: Bytes, value: Bytes) -> Result<i64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 		let write_opts = WriteOptions {
@@ -70,9 +71,9 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn hget(&self, key: Bytes, field: Bytes) -> Result<Option<Bytes>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		// Check if the hash exists and is valid, get version
 		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(None);
@@ -88,9 +89,9 @@ impl Storage {
 		Ok(None)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn hlen(&self, key: Bytes) -> Result<u64, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		if let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? {
 			Ok(meta_val.len)
 		} else {
@@ -98,13 +99,13 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn hmget(
 		&self,
 		key: Bytes,
 		fields: &[Bytes],
 	) -> Result<Vec<Option<Bytes>>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		// Check if the hash exists and is valid, get version
 		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(vec![None; fields.len()]);
@@ -150,9 +151,9 @@ impl Storage {
 			.collect())
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn hgetall(&self, key: Bytes) -> Result<Vec<(Bytes, Bytes)>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		// Check if the hash exists and is valid, get version
 		let Some(meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
 			return Ok(Vec::new());
@@ -196,9 +197,9 @@ impl Storage {
 		Ok(results)
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn hdel(&self, key: Bytes, fields: &[Bytes]) -> Result<i64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use futures::future;
 use log::warn;
+use nimbis_macros::storage_lock;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
 
@@ -21,14 +22,13 @@ impl Storage {
 		self.list_push(key, elements, false).await
 	}
 
+	#[storage_lock(write, key)]
 	async fn list_push(
 		&self,
 		key: Bytes,
 		elements: Vec<Bytes>,
 		is_left: bool,
 	) -> Result<u64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
-
 		if elements.is_empty() {
 			// If key exists, return len. If not, return 0.
 			if let Some(meta) = self.get_meta::<ListMetaValue>(&key).await? {
@@ -103,14 +103,13 @@ impl Storage {
 		self.list_pop(key, count, false).await
 	}
 
+	#[storage_lock(write, key)]
 	async fn list_pop(
 		&self,
 		key: Bytes,
 		count: Option<usize>,
 		is_left: bool,
 	) -> Result<Vec<Bytes>, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
-
 		let Some(mut meta_val) = self.get_meta::<ListMetaValue>(&key).await? else {
 			return Ok(Vec::new());
 		};
@@ -184,9 +183,9 @@ impl Storage {
 		Ok(results)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn llen(&self, key: Bytes) -> Result<u64, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		if let Some(meta_val) = self.get_meta::<ListMetaValue>(&key).await? {
 			Ok(meta_val.len)
 		} else {
@@ -194,6 +193,7 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn lrange(
 		&self,
@@ -201,7 +201,6 @@ impl Storage {
 		start: i64,
 		stop: i64,
 	) -> Result<Vec<Bytes>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		let Some(meta_val) = self.get_meta::<ListMetaValue>(&key).await? else {
 			return Ok(Vec::new());
 		};

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -403,8 +403,8 @@ mod tests {
 			.version;
 		assert_eq!(version_after_pop, version_v1);
 
-		let deleted = storage.del(key.clone()).await.unwrap();
-		assert!(deleted);
+		let deleted = storage.del([key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
 
 		let len = storage
 			.rpush(key.clone(), vec![Bytes::from("x")])

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -1,5 +1,6 @@
 use bytes::Buf;
 use bytes::Bytes;
+use nimbis_macros::storage_lock;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
 
@@ -11,9 +12,9 @@ use crate::string::meta::SetMetaValue;
 use crate::utils::user_key_prefix;
 
 impl Storage {
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn sadd(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 		let write_opts = WriteOptions {
@@ -84,9 +85,9 @@ impl Storage {
 		Ok(added_count)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn smembers(&self, key: Bytes) -> Result<Vec<Bytes>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		let Some(meta_val) = self.get_meta::<SetMetaValue>(&key).await? else {
 			return Ok(Vec::new());
 		};
@@ -127,9 +128,9 @@ impl Storage {
 		Ok(members)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn sismember(&self, key: Bytes, member: Bytes) -> Result<bool, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		let Some(meta_val) = self.get_meta::<SetMetaValue>(&key).await? else {
 			return Ok(false);
 		};
@@ -143,9 +144,9 @@ impl Storage {
 		Ok(found)
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn srem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 
@@ -193,9 +194,9 @@ impl Storage {
 		Ok(removed_count)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn scard(&self, key: Bytes) -> Result<u64, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		if let Some(meta_val) = self.get_meta::<SetMetaValue>(&key).await? {
 			Ok(meta_val.len)
 		} else {

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -336,8 +336,8 @@ mod tests {
 			.version;
 		assert_eq!(version_after_update, version_v1);
 
-		let deleted = storage.del(key.clone()).await.unwrap();
-		assert!(deleted);
+		let deleted = storage.del([key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
 
 		let added = storage.sadd(key.clone(), vec![m1.clone()]).await.unwrap();
 		assert_eq!(added, 1);

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use chrono::Utc;
+use nimbis_macros::storage_lock;
 use slatedb::config::PutOptions;
 use slatedb::config::Ttl;
 use slatedb::config::WriteOptions;
@@ -13,9 +14,9 @@ use crate::string::value::StringValue;
 use crate::utils::is_expired;
 
 impl Storage {
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn get(&self, key: Bytes) -> Result<Option<Bytes>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		match self.get_meta::<AnyValue>(&key).await? {
 			Some(AnyValue::String(val)) => Ok(Some(val.value)),
 			Some(val) => Err(StorageError::wrong_type(DataType::String, val.data_type())),
@@ -23,13 +24,9 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn set(&self, key: Bytes, value: Bytes) -> Result<(), StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
-		self.set_unlocked(key, value).await
-	}
-
-	pub(crate) async fn set_unlocked(&self, key: Bytes, value: Bytes) -> Result<(), StorageError> {
 		let key = StringKey::new(key);
 		let value = StringValue::new(value);
 
@@ -48,49 +45,40 @@ impl Storage {
 		Ok(self.del_many([key]).await? == 1)
 	}
 
+	#[storage_lock(write_many, keys)]
 	#[fastrace::trace]
 	pub async fn del_many<I>(&self, keys: I) -> Result<i64, StorageError>
 	where
 		I: IntoIterator<Item = Bytes>,
 	{
-		let keys: Vec<_> = keys.into_iter().collect();
-		let _guard = self.write_lock(keys.clone()).await;
 		let mut deleted = 0;
 
 		for key in keys {
-			if self.del_unlocked(key).await? {
-				deleted += 1;
+			let key = StringKey::new(key);
+
+			// We need to check existence to return correct number of deleted keys (0 or 1).
+			// Even if we don't use the meta value, we need to know if it exists.
+			if self.string_db.get(key.encode()).await?.is_none() {
+				continue;
 			}
+
+			let write_opts = WriteOptions {
+				await_durable: false,
+			};
+
+			self.string_db
+				.delete_with_options(key.encode(), &write_opts)
+				.await?;
+
+			deleted += 1;
 		}
 
 		Ok(deleted)
 	}
 
-	async fn del_unlocked(&self, key: Bytes) -> Result<bool, StorageError> {
-		let user_key = key;
-		let key = StringKey::new(user_key.clone());
-
-		// We need to check existence to return correct number of deleted keys (0 or 1).
-		// Even if we don't use the meta value, we need to know if it exists.
-		if self.string_db.get(key.encode()).await?.is_none() {
-			return Ok(false);
-		}
-
-		// Delete from string_db
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
-
-		self.string_db
-			.delete_with_options(key.encode(), &write_opts)
-			.await?;
-
-		Ok(true)
-	}
-
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn expire(&self, key: Bytes, expire_time: u64) -> Result<bool, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let user_key = key.clone();
 		let skey = StringKey::new(key);
 		let encoded_key = skey.encode();
@@ -134,9 +122,9 @@ impl Storage {
 		Ok(true)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn ttl(&self, key: Bytes) -> Result<Option<i64>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		let encoded_key = StringKey::new(key).encode();
 		let kv = match self.string_db.get_key_value(encoded_key.clone()).await? {
 			Some(kv) => kv,
@@ -161,23 +149,22 @@ impl Storage {
 		Ok(Some(ttl))
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn exists(&self, key: Bytes) -> Result<bool, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
-		self.exists_unlocked(key).await
+		Ok(self.get_meta::<AnyValue>(&key).await?.is_some())
 	}
 
+	#[storage_lock(read_many, keys)]
 	#[fastrace::trace]
 	pub async fn exists_many<I>(&self, keys: I) -> Result<i64, StorageError>
 	where
 		I: IntoIterator<Item = Bytes>,
 	{
-		let keys: Vec<_> = keys.into_iter().collect();
-		let _guard = self.read_lock(keys.clone()).await;
 		let mut count = 0;
 
 		for key in keys {
-			if self.exists_unlocked(key).await? {
+			if self.get_meta::<AnyValue>(&key).await?.is_some() {
 				count += 1;
 			}
 		}
@@ -185,13 +172,9 @@ impl Storage {
 		Ok(count)
 	}
 
-	async fn exists_unlocked(&self, key: Bytes) -> Result<bool, StorageError> {
-		Ok(self.get_meta::<AnyValue>(&key).await?.is_some())
-	}
-
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn incr(&self, key: Bytes) -> Result<i64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let current_val = match self.get_meta::<AnyValue>(&key).await? {
 			Some(AnyValue::String(val)) => Some(val.value),
 			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
@@ -216,15 +199,23 @@ impl Storage {
 				message: "ERR increment or decrement would overflow".to_string(),
 			})?;
 
-		self.set_unlocked(key, Bytes::from(int_val.to_string()))
+		let key = StringKey::new(key);
+		let value = StringValue::new(Bytes::from(int_val.to_string()));
+
+		let write_opts = WriteOptions {
+			await_durable: false,
+		};
+		let put_opts = PutOptions::default();
+		self.string_db
+			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
 			.await?;
 
 		Ok(int_val)
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn decr(&self, key: Bytes) -> Result<i64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let current_val = match self.get_meta::<AnyValue>(&key).await? {
 			Some(AnyValue::String(val)) => Some(val.value),
 			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
@@ -249,15 +240,23 @@ impl Storage {
 				message: "ERR increment or decrement would overflow".to_string(),
 			})?;
 
-		self.set_unlocked(key, Bytes::from(int_val.to_string()))
+		let key = StringKey::new(key);
+		let value = StringValue::new(Bytes::from(int_val.to_string()));
+
+		let write_opts = WriteOptions {
+			await_durable: false,
+		};
+		let put_opts = PutOptions::default();
+		self.string_db
+			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
 			.await?;
 
 		Ok(int_val)
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn append(&self, key: Bytes, append_val: Bytes) -> Result<usize, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let current_val = match self.get_meta::<AnyValue>(&key).await? {
 			Some(AnyValue::String(val)) => Some(val.value),
 			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
@@ -275,7 +274,16 @@ impl Storage {
 		};
 
 		let len = new_val.len();
-		self.set_unlocked(key, Bytes::from(new_val)).await?;
+		let key = StringKey::new(key);
+		let value = StringValue::new(Bytes::from(new_val));
+
+		let write_opts = WriteOptions {
+			await_durable: false,
+		};
+		let put_opts = PutOptions::default();
+		self.string_db
+			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
+			.await?;
 
 		Ok(len)
 	}

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -40,18 +40,16 @@ impl Storage {
 		Ok(())
 	}
 
-	#[fastrace::trace]
-	pub async fn del(&self, key: Bytes) -> Result<bool, StorageError> {
-		Ok(self.del_many([key]).await? == 1)
-	}
-
 	#[storage_lock(write_many, keys)]
 	#[fastrace::trace]
-	pub async fn del_many<I>(&self, keys: I) -> Result<i64, StorageError>
+	pub async fn del<I>(&self, keys: I) -> Result<i64, StorageError>
 	where
 		I: IntoIterator<Item = Bytes>,
 	{
 		let mut deleted = 0;
+		let write_opts = WriteOptions {
+			await_durable: false,
+		};
 
 		for key in keys {
 			let key = StringKey::new(key);
@@ -61,10 +59,6 @@ impl Storage {
 			if self.string_db.get(key.encode()).await?.is_none() {
 				continue;
 			}
-
-			let write_opts = WriteOptions {
-				await_durable: false,
-			};
 
 			self.string_db
 				.delete_with_options(key.encode(), &write_opts)
@@ -381,8 +375,8 @@ mod tests {
 		assert!(err.to_string().contains("WRONGTYPE"));
 
 		// Delete String
-		let deleted = storage.del(k.clone()).await.unwrap();
-		assert!(deleted);
+		let deleted = storage.del([k.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
 
 		// HSET should succeed
 		let res = storage.hset(k.clone(), f.clone(), v.clone()).await.unwrap();

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -16,10 +16,6 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn get(&self, key: Bytes) -> Result<Option<Bytes>, StorageError> {
 		let _guard = self.read_lock([key.clone()]).await;
-		self.get_unlocked(key).await
-	}
-
-	pub(crate) async fn get_unlocked(&self, key: Bytes) -> Result<Option<Bytes>, StorageError> {
 		match self.get_meta::<AnyValue>(&key).await? {
 			Some(AnyValue::String(val)) => Ok(Some(val.value)),
 			Some(val) => Err(StorageError::wrong_type(DataType::String, val.data_type())),
@@ -196,7 +192,11 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn incr(&self, key: Bytes) -> Result<i64, StorageError> {
 		let _guard = self.write_lock([key.clone()]).await;
-		let current_val = self.get_unlocked(key.clone()).await?;
+		let current_val = match self.get_meta::<AnyValue>(&key).await? {
+			Some(AnyValue::String(val)) => Some(val.value),
+			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
+			None => None,
+		};
 
 		let mut int_val: i64 = match current_val {
 			Some(bytes) => {
@@ -225,7 +225,11 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn decr(&self, key: Bytes) -> Result<i64, StorageError> {
 		let _guard = self.write_lock([key.clone()]).await;
-		let current_val = self.get_unlocked(key.clone()).await?;
+		let current_val = match self.get_meta::<AnyValue>(&key).await? {
+			Some(AnyValue::String(val)) => Some(val.value),
+			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
+			None => None,
+		};
 
 		let mut int_val: i64 = match current_val {
 			Some(bytes) => {
@@ -254,7 +258,11 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn append(&self, key: Bytes, append_val: Bytes) -> Result<usize, StorageError> {
 		let _guard = self.write_lock([key.clone()]).await;
-		let current_val = self.get_unlocked(key.clone()).await?;
+		let current_val = match self.get_meta::<AnyValue>(&key).await? {
+			Some(AnyValue::String(val)) => Some(val.value),
+			Some(val) => return Err(StorageError::wrong_type(DataType::String, val.data_type())),
+			None => None,
+		};
 
 		let new_val = match current_val {
 			Some(bytes) => {

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use futures::future;
+use nimbis_macros::storage_lock;
 use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
@@ -13,13 +14,13 @@ use crate::zset::member_key::MemberKey;
 use crate::zset::score_key::ScoreKey;
 
 impl Storage {
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn zadd(
 		&self,
 		key: Bytes,
 		elements: Vec<(f64, Bytes)>, // (score, member)
 	) -> Result<u64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 		let write_opts = WriteOptions {
@@ -157,6 +158,7 @@ impl Storage {
 		Ok(added_count)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn zrange(
 		&self,
@@ -165,7 +167,6 @@ impl Storage {
 		stop: isize,
 		with_scores: bool,
 	) -> Result<Vec<Bytes>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		if let Some(meta) = self.get_meta::<ZSetMetaValue>(&key).await? {
 			// Adjust indices
 			let len = meta.len as isize;
@@ -227,9 +228,9 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn zscore(&self, key: Bytes, member: Bytes) -> Result<Option<f64>, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		let Some(meta_val) = self.get_meta::<ZSetMetaValue>(&key).await? else {
 			return Ok(None);
 		};
@@ -246,9 +247,9 @@ impl Storage {
 		}
 	}
 
+	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn zrem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
-		let _guard = self.write_lock([key.clone()]).await;
 		let meta_key = MetaKey::new(key.clone());
 		let meta_encoded_key = meta_key.encode();
 
@@ -321,9 +322,9 @@ impl Storage {
 		Ok(removed_count)
 	}
 
+	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn zcard(&self, key: Bytes) -> Result<u64, StorageError> {
-		let _guard = self.read_lock([key.clone()]).await;
 		if let Some(meta_val) = self.get_meta::<ZSetMetaValue>(&key).await? {
 			Ok(meta_val.len)
 		} else {

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -508,8 +508,8 @@ mod tests {
 			.version;
 		assert_eq!(version_after_new_member, version_v1);
 
-		let deleted = storage.del(key.clone()).await.unwrap();
-		assert!(deleted);
+		let deleted = storage.del([key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
 
 		let added = storage
 			.zadd(key.clone(), vec![(10.0, Bytes::from("m1"))])

--- a/nimbis/src/cmd/cmd_del.rs
+++ b/nimbis/src/cmd/cmd_del.rs
@@ -29,7 +29,7 @@ impl Cmd for DelCmd {
 	}
 
 	async fn do_cmd(&self, storage: &Storage, args: &[Bytes], _ctx: &CmdContext) -> RespValue {
-		match storage.del_many(args.iter().cloned()).await {
+		match storage.del(args.iter().cloned()).await {
 			Ok(deleted) => RespValue::Integer(deleted),
 			Err(e) => RespValue::error(e.to_string()),
 		}


### PR DESCRIPTION
## Summary
- Add a new `#[storage_lock(...)]` attribute macro in `nimbis-macros` to inject `read_lock`, `write_lock`, `read_many`, `write_many`, and `global_write_lock` guards.
- Migrate all `nimbis-storage/src` entrypoints to the macro so lock acquisition is declared once at the function level instead of repeated inline.
- Remove the remaining `*_unlocked` helpers from `storage_string.rs` and inline their logic.

## Testing
- Added macro coverage for single-key, multi-key, and global write locking behavior.
- Ran `cargo test -p nimbis-macros --no-fail-fast`.
- Ran `cargo test -p nimbis-storage --no-fail-fast`.
- Ran `just check` and `just fmt`.