### PR TITLE
feat: add SlateDB segmented storage

### DIFF
--- a/.github/workflows/flamegraph.yml
+++ b/.github/workflows/flamegraph.yml
@@ -3,6 +3,10 @@ name: Performance Flamegraph
 on:
   workflow_dispatch:
     inputs:
+      target_ref:
+        description: Git ref to profile. Defaults to the workflow ref.
+        required: false
+        type: string
       pr_number:
         description: Optional pull request number to comment flamegraph result on
         required: false
@@ -17,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_ref || github.ref }}
 
       - name: Install dependencies
         run: |
@@ -43,12 +49,28 @@ jobs:
         run: |
           # Enable debug symbols in release mode for meaningful flamegraphs
           RUSTFLAGS="-g" cargo build --release
+          # Build xtask before profiling so perf does not sample an idle server
+          # while Cargo compiles the benchmark driver.
+          cargo build -p xtask
 
       - name: Run Benchmark and Capture Profile
         run: |
+          set -euo pipefail
+
           # 1. Start Nimbis in background
-          ./target/release/nimbis &
+          NIMBIS_OBJECT_STORE_URL=file:nimbis_flamegraph_store ./target/release/nimbis &
           NIMBIS_PID=$!
+          PERF_PID=""
+          cleanup() {
+            if [ -n "$PERF_PID" ]; then
+              sudo kill -INT "$PERF_PID" >/dev/null 2>&1 || true
+              wait "$PERF_PID" || true
+            fi
+            kill "$NIMBIS_PID" >/dev/null 2>&1 || true
+            wait "$NIMBIS_PID" || true
+          }
+          trap cleanup EXIT
+
           echo "Nimbis started with PID $NIMBIS_PID"
           
           # Give it a moment to start
@@ -65,18 +87,22 @@ jobs:
           PERF_PID=$!
           
           # 3. Run Redis Benchmark
-          echo "Running redis-benchmark..."
-          # Run a decent workload
-          redis-benchmark -q -t set,get,hset,hget,lpush,lpop,sadd,srem,zadd,zrem -n 100000 -c 100 -r 100000 -d 512 || true
-          
+          echo "Running redis-benchmark comparison profile..."
+          N=100000 C=100 R=100000 D=512 P=1 OUTPUT_DIR=benchmark_flamegraph \
+            cargo xtask redis-benchmark --profile comparison \
+            > benchmark.txt
+
           # 4. Stop perf
           echo "Stopping perf..."
           sudo kill -INT $PERF_PID
           # Wait for perf to write data
           wait $PERF_PID || true
+          PERF_PID=""
           
           # 5. Stop Nimbis
           kill $NIMBIS_PID
+          wait $NIMBIS_PID || true
+          trap - EXIT
           
           # 6. Generate Flamegraph
           echo "Generating flamegraph..."
@@ -96,7 +122,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: flamegraph
-          path: flamegraph.svg
+          path: |
+            flamegraph.svg
+            out.folded
+            benchmark.txt
 
       - name: Comment on PR
         if: inputs.pr_number
@@ -106,6 +135,7 @@ jobs:
             const run_id = context.runId;
             const repo_url = context.payload.repository.html_url;
             const rawPrNumber = (context.payload.inputs?.pr_number ?? '').trim();
+            const targetRef = (context.payload.inputs?.target_ref ?? '').trim() || context.ref;
             const validPrNumberPattern = /^[1-9]\d*$/;
 
             if (!validPrNumberPattern.test(rawPrNumber)) {
@@ -118,8 +148,10 @@ jobs:
             const body = `### 🔥 Performance Flamegraph
             
             A flamegraph has been generated for this Pull Request.
+
+            Target ref: \`${targetRef}\`
             
-            You can download the **flamegraph.svg** from the [Artifacts section of this Run](${repo_url}/actions/runs/${run_id}).
+            You can download **flamegraph.svg**, **out.folded**, and **benchmark.txt** from the [Artifacts section of this Run](${repo_url}/actions/runs/${run_id}).
             
             _Note: Download the file and open it in a browser to explore the stack traces interactively._`;
             

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,34 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +138,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -196,18 +155,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auto_enums"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "autocfg"
@@ -308,6 +255,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,7 +325,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -379,7 +337,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -416,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -438,10 +396,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -551,41 +529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,17 +552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,7 +569,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -645,12 +577,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duration-str"
@@ -710,13 +636,14 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5666e8ca4ec174d896fb742789c29b1bea9319dcfd623c41bececc0a60c4939d"
+checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.9.2",
+ "tokio",
 ]
 
 [[package]]
@@ -753,7 +680,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -808,18 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,40 +763,39 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642093b1a72c4a0ef89862484d669a353e732974781bb9c49a979526d1e30edc"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
 dependencies = [
+ "anyhow",
  "equivalent",
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "madsim-tokio",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
  "mixtrics",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db9c0e4648b13e9216d785b308d43751ca975301aeb83e607ec630b6f956944"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
 dependencies = [
+ "anyhow",
  "bincode",
  "bytes",
  "cfg-if",
- "itertools 0.14.0",
- "madsim-tokio",
+ "foyer-tokio",
  "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "twox-hash",
 ]
 
@@ -890,60 +810,69 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040dc38acbfca8f1def26bbbd9e9199090884aabb15de99f7bf4060be66ff608"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
 dependencies = [
- "arc-swap",
+ "anyhow",
  "bitflags",
  "cmsketch",
  "equivalent",
  "foyer-common",
  "foyer-intrusive-collections",
- "hashbrown 0.15.5",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
- "madsim-tokio",
+ "mea",
  "mixtrics",
  "parking_lot",
+ "paste",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a77ed888da490e997da6d6d62fcbce3f202ccf28be098c4ea595ca046fc4a9"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
  "allocator-api2",
  "anyhow",
- "auto_enums",
  "bytes",
+ "core_affinity",
  "equivalent",
- "flume",
+ "fastant",
  "foyer-common",
  "foyer-memory",
+ "foyer-tokio",
  "fs4",
  "futures-core",
  "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring",
  "itertools 0.14.0",
  "libc",
  "lz4",
- "madsim-tokio",
- "ordered_hash_map",
+ "mea",
  "parking_lot",
- "paste",
  "pin-project",
  "rand 0.9.2",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -1022,7 +951,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1106,6 +1035,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1160,15 +1090,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1179,9 +1100,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1189,6 +1119,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1439,12 +1374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1411,17 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -1585,6 +1525,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,61 +1559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "madsim"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18351aac4194337d6ea9ffbd25b3d1540ecc0754142af1bff5ba7392d1f6f771"
-dependencies = [
- "ahash",
- "async-channel",
- "async-stream",
- "async-task",
- "bincode",
- "bytes",
- "downcast-rs",
- "errno",
- "futures-util",
- "lazy_static",
- "libc",
- "madsim-macros",
- "naive-timer",
- "panic-message",
- "rand 0.8.6",
- "rand_xoshiro 0.6.0",
- "rustversion",
- "serde",
- "spin",
- "tokio",
- "tokio-util",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "madsim-macros"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "madsim-tokio"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5"
-dependencies = [
- "madsim",
- "spin",
- "tokio",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1575,15 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -1720,21 +1623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "naive-timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
 name = "nimbis"
 version = "0.1.0"
 dependencies = [
@@ -1770,7 +1658,7 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "rstest",
- "syn 2.0.117",
+ "syn",
  "tokio",
 ]
 
@@ -1886,16 +1774,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
@@ -1905,7 +1795,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "serde",
@@ -2026,15 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered_hash_map"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e5f22bf6dd04abd854a8874247813a8fa2c8c1260eba6fbb150270ce7c176"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "ouroboros"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,7 +1936,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2067,12 +1948,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "panic-message"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
 
 [[package]]
 name = "parking"
@@ -2129,7 +2004,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2155,7 +2030,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2235,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2266,7 +2141,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2286,7 +2161,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -2300,7 +2175,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -2323,17 +2198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -2411,33 +2286,23 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2452,15 +2317,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -2469,21 +2325,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2641,7 +2494,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-ident",
 ]
 
@@ -2843,7 +2696,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2926,7 +2779,7 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2968,15 +2821,14 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slatedb"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb?branch=main#7c1d61e26b1dbc780f7c00bd04fcc03e4a196ef1"
+version = "0.13.0"
+source = "git+https://github.com/slatedb/slatedb?branch=main#abb8edda40b936b20c1c123e11dbdfac8bac6f3a"
 dependencies = [
- "anyhow",
+ "async-channel",
  "async-trait",
  "atomic",
  "backon",
  "bitflags",
- "bytemuck",
  "bytes",
  "chrono",
  "crc32fast",
@@ -2989,17 +2841,18 @@ dependencies = [
  "foyer",
  "futures",
  "log",
+ "lru",
  "object_store",
- "once_cell",
  "ouroboros",
  "parking_lot",
  "rand 0.9.2",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
  "serde",
  "serde_json",
  "siphasher",
  "slatedb-common",
  "slatedb-txn-obj",
+ "smallvec",
  "sysinfo",
  "thiserror 1.0.69",
  "thread_local",
@@ -3014,17 +2867,19 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb?branch=main#7c1d61e26b1dbc780f7c00bd04fcc03e4a196ef1"
+version = "0.13.0"
+source = "git+https://github.com/slatedb/slatedb?branch=main#abb8edda40b936b20c1c123e11dbdfac8bac6f3a"
 dependencies = [
  "chrono",
+ "log",
+ "serde",
  "tokio",
 ]
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.11.1"
-source = "git+https://github.com/slatedb/slatedb?branch=main#7c1d61e26b1dbc780f7c00bd04fcc03e4a196ef1"
+version = "0.13.0"
+source = "git+https://github.com/slatedb/slatedb?branch=main#abb8edda40b936b20c1c123e11dbdfac8bac6f3a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3032,6 +2887,7 @@ dependencies = [
  "futures",
  "log",
  "object_store",
+ "parking_lot",
  "slatedb-common",
  "thiserror 1.0.69",
 ]
@@ -3059,15 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,12 +2928,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3096,17 +2937,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -3136,7 +2966,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3192,7 +3022,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3203,7 +3033,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3306,7 +3136,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3355,21 +3185,6 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3592,7 +3407,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3842,7 +3657,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4007,7 +3822,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4018,7 +3833,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4215,7 +4030,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4231,7 +4046,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4315,7 +4130,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4336,7 +4151,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4356,7 +4171,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4396,7 +4211,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/nimbis-storage/src/compaction_filter.rs
+++ b/nimbis-storage/src/compaction_filter.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Buf;
 use bytes::Bytes;
 use log::info;
 use log::warn;
@@ -19,6 +18,8 @@ use crate::data_type::DataType;
 use crate::segment::Segment;
 use crate::string::meta::AnyValue;
 use crate::string::meta::MetaKey;
+use crate::utils::decode_collection_generation;
+use crate::utils::is_expired;
 
 // CollectionCompactionFilter is installed on the single segmented DB.
 pub struct CollectionCompactionFilter {
@@ -26,19 +27,11 @@ pub struct CollectionCompactionFilter {
 }
 
 impl CollectionCompactionFilter {
-	/// Decode a sub-key to extract the user_key portion.
-	/// Payload format after the segment byte: key_len(u16 BE) + user_key + ...
-	fn decode_sub_key(key: &[u8]) -> Option<Bytes> {
-		if key.len() < 2 {
-			return None;
-		}
-		let mut buf = key;
-		let key_len = buf.get_u16() as usize;
-		if buf.len() < key_len {
-			return None;
-		}
-		let user_key = Bytes::copy_from_slice(&buf[..key_len]);
-		Some(user_key)
+	/// Decode a sub-key to extract the user key and collection generation.
+	/// Payload format after the segment byte: key_len(u16 BE) + user_key +
+	/// generation(u64 BE) + ...
+	fn decode_sub_key(key: &[u8]) -> Option<(Bytes, u64)> {
+		decode_collection_generation(key)
 	}
 
 	fn collection_type(segment: u8) -> Option<DataType> {
@@ -74,8 +67,8 @@ impl CompactionFilter for CollectionCompactionFilter {
 			return Ok(CompactionFilterDecision::Keep);
 		};
 
-		// Decode sub-key to get user_key
-		let Some(user_key) = Self::decode_sub_key(&entry.key[1..]) else {
+		// Decode sub-key to get user key and embedded generation.
+		let Some((user_key, key_generation)) = Self::decode_sub_key(&entry.key[1..]) else {
 			info!(
 				"[{:?}Filter] Invalid key format: {:?}",
 				data_type, entry.key
@@ -107,6 +100,14 @@ impl CompactionFilter for CollectionCompactionFilter {
 			}
 		};
 
+		if is_expired(kv.expire_ts) {
+			info!(
+				"[{:?}Filter] Drop[Meta expired] key: {:?}",
+				data_type, user_key
+			);
+			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
+		}
+
 		let meta_encoded = kv.value;
 
 		let any_val = match AnyValue::decode(&meta_encoded) {
@@ -132,13 +133,13 @@ impl CompactionFilter for CollectionCompactionFilter {
 			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 		}
 
-		// Check version — old generation sub-keys should be tombstoned
-		if let Some(meta_version) = any_val.version()
-			&& entry.seq < meta_version
+		// Check generation — old generation sub-keys should be tombstoned.
+		if let Some(meta_generation) = any_val.version()
+			&& meta_generation != key_generation
 		{
 			info!(
-				"[{:?}Filter] Drop[old seq: meta_version {}, data_seq {}] key: {:?}",
-				data_type, meta_version, entry.seq, user_key
+				"[{:?}Filter] Drop[stale generation: meta {}, key {}] key: {:?}",
+				data_type, meta_generation, key_generation, user_key
 			);
 			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 		}
@@ -210,16 +211,17 @@ mod tests {
 		let _ = filter_db.set(db.clone());
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
-		// Test Valid seq (10)
+		// Test valid generation (10)
 		let mut valid_key = BytesMut::new();
 		valid_key.put_u16(user_key.len() as u16);
 		valid_key.extend_from_slice(&user_key);
+		valid_key.put_u64(10);
 		valid_key.put_u32(5); // field len
 		valid_key.put_slice(b"field");
 		let valid_entry = RowEntry {
 			key: Segment::Hash.wrap(valid_key.freeze()),
 			value: ValueDeletable::Value(Bytes::from("val")),
-			seq: 10,
+			seq: 1,
 			create_ts: None,
 			expire_ts: None,
 		};
@@ -228,16 +230,17 @@ mod tests {
 			CompactionFilterDecision::Keep
 		);
 
-		// Test Invalid seq (9)
+		// Test stale generation (9)
 		let mut invalid_key = BytesMut::new();
 		invalid_key.put_u16(user_key.len() as u16);
 		invalid_key.extend_from_slice(&user_key);
+		invalid_key.put_u64(9);
 		invalid_key.put_u32(5);
 		invalid_key.put_slice(b"field");
 		let invalid_entry = RowEntry {
 			key: Segment::Hash.wrap(invalid_key.freeze()),
 			value: ValueDeletable::Value(Bytes::from("val")),
-			seq: 9,
+			seq: 1,
 			create_ts: None,
 			expire_ts: None,
 		};
@@ -283,10 +286,11 @@ mod tests {
 		let _ = filter_db.set(db.clone());
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
-		let build_sub_key = |member: &[u8]| -> Bytes {
+		let build_sub_key = |generation: u64, member: &[u8]| -> Bytes {
 			let mut key = BytesMut::new();
 			key.put_u16(user_key.len() as u16);
 			key.extend_from_slice(&user_key);
+			key.put_u64(generation);
 			key.put_u32(member.len() as u32);
 			key.extend_from_slice(member);
 			Segment::Set.wrap(key.freeze())
@@ -295,9 +299,9 @@ mod tests {
 		let members: &[&[u8]] = &[b"alice", b"bob", b"carol"];
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
-				seq: 42,
+				seq: 1,
 				create_ts: None,
 				expire_ts: None,
 			};
@@ -321,9 +325,9 @@ mod tests {
 		// Now all sub-keys should be marked for deletion (orphaned)
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
-				seq: 42,
+				seq: 1,
 				create_ts: None,
 				expire_ts: None,
 			};
@@ -341,12 +345,12 @@ mod tests {
 			.await
 			.unwrap();
 
-		// Old seq=42 data should still be reclaimed
+		// Old generation=42 data should still be reclaimed
 		for member in members {
 			let entry = RowEntry {
-				key: build_sub_key(member),
+				key: build_sub_key(42, member),
 				value: ValueDeletable::Value(Bytes::new()),
-				seq: 42,
+				seq: 1,
 				create_ts: None,
 				expire_ts: None,
 			};
@@ -358,11 +362,11 @@ mod tests {
 			);
 		}
 
-		// New seq=100 data should be kept
+		// New generation=100 data should be kept
 		let new_entry = RowEntry {
-			key: build_sub_key(b"dave"),
+			key: build_sub_key(100, b"dave"),
 			value: ValueDeletable::Value(Bytes::new()),
-			seq: 100,
+			seq: 1,
 			create_ts: None,
 			expire_ts: None,
 		};

--- a/nimbis-storage/src/compaction_filter.rs
+++ b/nimbis-storage/src/compaction_filter.rs
@@ -18,7 +18,7 @@ use crate::data_type::DataType;
 use crate::segment::Segment;
 use crate::string::meta::AnyValue;
 use crate::string::meta::MetaKey;
-use crate::utils::decode_collection_generation;
+use crate::utils::decode_collection_version;
 use crate::utils::is_expired;
 
 // CollectionCompactionFilter is installed on the single segmented DB.
@@ -27,11 +27,11 @@ pub struct CollectionCompactionFilter {
 }
 
 impl CollectionCompactionFilter {
-	/// Decode a sub-key to extract the user key and collection generation.
+	/// Decode a sub-key to extract the user key and collection version.
 	/// Payload format after the segment byte: key_len(u16 BE) + user_key +
-	/// generation(u64 BE) + ...
+	/// version(u64 BE) + ...
 	fn decode_sub_key(key: &[u8]) -> Option<(Bytes, u64)> {
-		decode_collection_generation(key)
+		decode_collection_version(key)
 	}
 
 	fn collection_type(segment: u8) -> Option<DataType> {
@@ -67,8 +67,8 @@ impl CompactionFilter for CollectionCompactionFilter {
 			return Ok(CompactionFilterDecision::Keep);
 		};
 
-		// Decode sub-key to get user key and embedded generation.
-		let Some((user_key, key_generation)) = Self::decode_sub_key(&entry.key[1..]) else {
+		// Decode sub-key to get user key and embedded version.
+		let Some((user_key, key_version)) = Self::decode_sub_key(&entry.key[1..]) else {
 			info!(
 				"[{:?}Filter] Invalid key format: {:?}",
 				data_type, entry.key
@@ -133,13 +133,13 @@ impl CompactionFilter for CollectionCompactionFilter {
 			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 		}
 
-		// Check generation — old generation sub-keys should be tombstoned.
-		if let Some(meta_generation) = any_val.version()
-			&& meta_generation != key_generation
+		// Check version — old version sub-keys should be tombstoned.
+		if let Some(meta_version) = any_val.version()
+			&& meta_version != key_version
 		{
 			info!(
-				"[{:?}Filter] Drop[stale generation: meta {}, key {}] key: {:?}",
-				data_type, meta_generation, key_generation, user_key
+				"[{:?}Filter] Drop[stale version: meta {}, key {}] key: {:?}",
+				data_type, meta_version, key_version, user_key
 			);
 			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 		}
@@ -211,7 +211,7 @@ mod tests {
 		let _ = filter_db.set(db.clone());
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
-		// Test valid generation (10)
+		// Test valid version (10)
 		let mut valid_key = BytesMut::new();
 		valid_key.put_u16(user_key.len() as u16);
 		valid_key.extend_from_slice(&user_key);
@@ -230,7 +230,7 @@ mod tests {
 			CompactionFilterDecision::Keep
 		);
 
-		// Test stale generation (9)
+		// Test stale version (9)
 		let mut invalid_key = BytesMut::new();
 		invalid_key.put_u16(user_key.len() as u16);
 		invalid_key.extend_from_slice(&user_key);
@@ -286,11 +286,11 @@ mod tests {
 		let _ = filter_db.set(db.clone());
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
-		let build_sub_key = |generation: u64, member: &[u8]| -> Bytes {
+		let build_sub_key = |version: u64, member: &[u8]| -> Bytes {
 			let mut key = BytesMut::new();
 			key.put_u16(user_key.len() as u16);
 			key.extend_from_slice(&user_key);
-			key.put_u64(generation);
+			key.put_u64(version);
 			key.put_u32(member.len() as u32);
 			key.extend_from_slice(member);
 			Segment::Set.wrap(key.freeze())
@@ -345,7 +345,7 @@ mod tests {
 			.await
 			.unwrap();
 
-		// Old generation=42 data should still be reclaimed
+		// Old version=42 data should still be reclaimed
 		for member in members {
 			let entry = RowEntry {
 				key: build_sub_key(42, member),
@@ -362,7 +362,7 @@ mod tests {
 			);
 		}
 
-		// New generation=100 data should be kept
+		// New version=100 data should be kept
 		let new_entry = RowEntry {
 			key: build_sub_key(100, b"dave"),
 			value: ValueDeletable::Value(Bytes::new()),

--- a/nimbis-storage/src/compaction_filter.rs
+++ b/nimbis-storage/src/compaction_filter.rs
@@ -13,20 +13,21 @@ use slatedb::CompactionJobContext;
 use slatedb::Db;
 use slatedb::RowEntry;
 use slatedb::ValueDeletable;
+use tokio::sync::OnceCell;
 
 use crate::data_type::DataType;
+use crate::segment::Segment;
 use crate::string::meta::AnyValue;
 use crate::string::meta::MetaKey;
 
-// CollectionCompactionFilter used by hash_db, list_db, set_db, zset_db
+// CollectionCompactionFilter is installed on the single segmented DB.
 pub struct CollectionCompactionFilter {
-	pub(crate) string_db: Arc<Db>,
-	pub(crate) data_type: DataType,
+	pub(crate) db: Arc<OnceCell<Arc<Db>>>,
 }
 
 impl CollectionCompactionFilter {
 	/// Decode a sub-key to extract the user_key portion.
-	/// Sub-key format: key_len(u16 BE) + user_key + ...
+	/// Payload format after the segment byte: key_len(u16 BE) + user_key + ...
 	fn decode_sub_key(key: &[u8]) -> Option<Bytes> {
 		if key.len() < 2 {
 			return None;
@@ -38,6 +39,16 @@ impl CollectionCompactionFilter {
 		}
 		let user_key = Bytes::copy_from_slice(&buf[..key_len]);
 		Some(user_key)
+	}
+
+	fn collection_type(segment: u8) -> Option<DataType> {
+		match segment {
+			b'h' => Some(DataType::Hash),
+			b'l' => Some(DataType::List),
+			b'S' => Some(DataType::Set),
+			b'z' => Some(DataType::ZSet),
+			_ => None,
+		}
 	}
 }
 
@@ -52,31 +63,45 @@ impl CompactionFilter for CollectionCompactionFilter {
 			return Ok(CompactionFilterDecision::Keep);
 		}
 
+		let Some(segment) = entry.key.first().copied() else {
+			return Ok(CompactionFilterDecision::Keep);
+		};
+		let Some(data_type) = Self::collection_type(segment) else {
+			return Ok(CompactionFilterDecision::Keep);
+		};
+		let Some(db) = self.db.get() else {
+			warn!("[{:?}Filter] Keep[DB handle not initialized]", data_type);
+			return Ok(CompactionFilterDecision::Keep);
+		};
+
 		// Decode sub-key to get user_key
-		let Some(user_key) = Self::decode_sub_key(&entry.key) else {
+		let Some(user_key) = Self::decode_sub_key(&entry.key[1..]) else {
 			info!(
 				"[{:?}Filter] Invalid key format: {:?}",
-				self.data_type, entry.key
+				data_type, entry.key
 			);
 			return Ok(CompactionFilterDecision::Keep);
 		};
 
-		// Lookup metadata in string_db
+		// Lookup metadata in the meta segment.
 		let meta_key = MetaKey::new(user_key.clone());
-		let kv = match self.string_db.get_key_value(meta_key.encode()).await {
+		let kv = match db
+			.get_key_value(Segment::Meta.wrap(meta_key.encode()))
+			.await
+		{
 			Ok(Some(v)) => v,
 			Ok(None) => {
 				// Metadata missing -> Orphaned sub-key -> Delete
 				info!(
 					"[{:?}Filter] Drop[Meta missing] key: {:?}",
-					self.data_type, user_key
+					data_type, user_key
 				);
 				return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 			}
 			Err(e) => {
 				warn!(
 					"[{:?}Filter] Keep[Get meta failed: {:?}] key: {:?}",
-					self.data_type, e, user_key
+					data_type, e, user_key
 				);
 				return Ok(CompactionFilterDecision::Keep);
 			}
@@ -89,18 +114,18 @@ impl CompactionFilter for CollectionCompactionFilter {
 			Err(e) => {
 				warn!(
 					"[{:?}Filter] Keep[Decode meta failed: {:?}] key: {:?}",
-					self.data_type, e, user_key
+					data_type, e, user_key
 				);
 				return Ok(CompactionFilterDecision::Keep);
 			}
 		};
 
 		// Check type — type mismatch means orphaned sub-key from a type collision
-		if any_val.data_type() != self.data_type {
+		if any_val.data_type() != data_type {
 			info!(
 				"[{:?}Filter] Drop[Type mismatch: expected {:?}, found {:?}] key: {:?}",
-				self.data_type,
-				self.data_type,
+				data_type,
+				data_type,
 				any_val.data_type(),
 				user_key
 			);
@@ -113,7 +138,7 @@ impl CompactionFilter for CollectionCompactionFilter {
 		{
 			info!(
 				"[{:?}Filter] Drop[old seq: meta_version {}, data_seq {}] key: {:?}",
-				self.data_type, meta_version, entry.seq, user_key
+				data_type, meta_version, entry.seq, user_key
 			);
 			return Ok(CompactionFilterDecision::Modify(ValueDeletable::Tombstone));
 		}
@@ -127,8 +152,7 @@ impl CompactionFilter for CollectionCompactionFilter {
 }
 
 pub struct CollectionCompactionFilterSupplier {
-	pub string_db: Arc<Db>,
-	pub data_type: DataType,
+	pub db: Arc<OnceCell<Arc<Db>>>,
 }
 
 #[async_trait]
@@ -138,8 +162,7 @@ impl CompactionFilterSupplier for CollectionCompactionFilterSupplier {
 		_context: &CompactionJobContext,
 	) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
 		Ok(Box::new(CollectionCompactionFilter {
-			string_db: self.string_db.clone(),
-			data_type: self.data_type,
+			db: self.db.clone(),
 		}))
 	}
 }
@@ -163,31 +186,29 @@ mod tests {
 
 		use crate::string::meta::HashMetaValue;
 
-		// Setup string_db using local temp dir
+		// Setup single DB using local temp dir
 		let temp_dir = std::env::temp_dir().join(format!("nimbis-test-{}", ulid::Ulid::new()));
 		tokio::fs::create_dir_all(&temp_dir).await.unwrap();
 		let object_store = Arc::new(LocalFileSystem::new_with_prefix(&temp_dir).unwrap());
 
-		let string_db = Db::builder(Path::from("/string"), object_store)
+		let db = Db::builder(Path::from("/db"), object_store)
 			.build()
 			.await
 			.unwrap();
-		let string_db = Arc::new(string_db);
+		let db = Arc::new(db);
 
 		// Put Metadata (version 10)
 		let user_key = Bytes::from("myhash");
 		let meta_key = MetaKey::new(user_key.clone());
 		let meta_val = HashMetaValue::new(10, 5);
-		string_db
-			.put(meta_key.encode(), meta_val.encode())
+		db.put(Segment::Meta.wrap(meta_key.encode()), meta_val.encode())
 			.await
 			.unwrap();
 
 		// Setup Filter
-		let mut filter = CollectionCompactionFilter {
-			string_db: string_db.clone(),
-			data_type: DataType::Hash,
-		};
+		let filter_db = Arc::new(OnceCell::new());
+		let _ = filter_db.set(db.clone());
+		let mut filter = CollectionCompactionFilter { db: filter_db };
 
 		// Test Valid seq (10)
 		let mut valid_key = BytesMut::new();
@@ -196,7 +217,7 @@ mod tests {
 		valid_key.put_u32(5); // field len
 		valid_key.put_slice(b"field");
 		let valid_entry = RowEntry {
-			key: valid_key.freeze(),
+			key: Segment::Hash.wrap(valid_key.freeze()),
 			value: ValueDeletable::Value(Bytes::from("val")),
 			seq: 10,
 			create_ts: None,
@@ -214,7 +235,7 @@ mod tests {
 		invalid_key.put_u32(5);
 		invalid_key.put_slice(b"field");
 		let invalid_entry = RowEntry {
-			key: invalid_key.freeze(),
+			key: Segment::Hash.wrap(invalid_key.freeze()),
 			value: ValueDeletable::Value(Bytes::from("val")),
 			seq: 9,
 			create_ts: None,
@@ -239,30 +260,28 @@ mod tests {
 
 		use crate::string::meta::SetMetaValue;
 
-		// Setup string_db
+		// Setup single DB
 		let temp_dir = std::env::temp_dir().join(format!("nimbis-test-{}", ulid::Ulid::new()));
 		tokio::fs::create_dir_all(&temp_dir).await.unwrap();
 		let object_store = Arc::new(LocalFileSystem::new_with_prefix(&temp_dir).unwrap());
 
-		let string_db = Db::builder(Path::from("/string"), object_store)
+		let db = Db::builder(Path::from("/db"), object_store)
 			.build()
 			.await
 			.unwrap();
-		let string_db = Arc::new(string_db);
+		let db = Arc::new(db);
 
 		// Put Metadata for a Set (version=42, len=3)
 		let user_key = Bytes::from("myset");
 		let meta_key = MetaKey::new(user_key.clone());
 		let meta_val = SetMetaValue::new(42, 3);
-		string_db
-			.put(meta_key.encode(), meta_val.encode())
+		db.put(Segment::Meta.wrap(meta_key.encode()), meta_val.encode())
 			.await
 			.unwrap();
 
-		let mut filter = CollectionCompactionFilter {
-			string_db: string_db.clone(),
-			data_type: DataType::Set,
-		};
+		let filter_db = Arc::new(OnceCell::new());
+		let _ = filter_db.set(db.clone());
+		let mut filter = CollectionCompactionFilter { db: filter_db };
 
 		let build_sub_key = |member: &[u8]| -> Bytes {
 			let mut key = BytesMut::new();
@@ -270,7 +289,7 @@ mod tests {
 			key.extend_from_slice(&user_key);
 			key.put_u32(member.len() as u32);
 			key.extend_from_slice(member);
-			key.freeze()
+			Segment::Set.wrap(key.freeze())
 		};
 
 		let members: &[&[u8]] = &[b"alice", b"bob", b"carol"];
@@ -293,9 +312,9 @@ mod tests {
 		// Simulate DEL: remove the metadata
 		let write_opts = WriteOptions {
 			await_durable: false,
+			..WriteOptions::default()
 		};
-		string_db
-			.delete_with_options(meta_key.encode(), &write_opts)
+		db.delete_with_options(Segment::Meta.wrap(meta_key.encode()), &write_opts)
 			.await
 			.unwrap();
 
@@ -318,8 +337,7 @@ mod tests {
 
 		// Simulate re-creation with new version: put meta with version=100
 		let new_meta_val = SetMetaValue::new(100, 1);
-		string_db
-			.put(meta_key.encode(), new_meta_val.encode())
+		db.put(Segment::Meta.wrap(meta_key.encode()), new_meta_val.encode())
 			.await
 			.unwrap();
 

--- a/nimbis-storage/src/compaction_filter.rs
+++ b/nimbis-storage/src/compaction_filter.rs
@@ -15,7 +15,10 @@ use slatedb::ValueDeletable;
 use tokio::sync::OnceCell;
 
 use crate::data_type::DataType;
-use crate::segment::Segment;
+use crate::segment::HASH_PREFIX;
+use crate::segment::LIST_PREFIX;
+use crate::segment::SET_PREFIX;
+use crate::segment::ZSET_PREFIX;
 use crate::string::meta::AnyValue;
 use crate::string::meta::MetaKey;
 use crate::utils::decode_collection_version;
@@ -36,10 +39,10 @@ impl CollectionCompactionFilter {
 
 	fn collection_type(segment: u8) -> Option<DataType> {
 		match segment {
-			b'h' => Some(DataType::Hash),
-			b'l' => Some(DataType::List),
-			b'S' => Some(DataType::Set),
-			b'z' => Some(DataType::ZSet),
+			HASH_PREFIX => Some(DataType::Hash),
+			LIST_PREFIX => Some(DataType::List),
+			SET_PREFIX => Some(DataType::Set),
+			ZSET_PREFIX => Some(DataType::ZSet),
 			_ => None,
 		}
 	}
@@ -78,10 +81,7 @@ impl CompactionFilter for CollectionCompactionFilter {
 
 		// Lookup metadata in the meta segment.
 		let meta_key = MetaKey::new(user_key.clone());
-		let kv = match db
-			.get_key_value(Segment::Meta.wrap(meta_key.encode()))
-			.await
-		{
+		let kv = match db.get_key_value(meta_key.encode()).await {
 			Ok(Some(v)) => v,
 			Ok(None) => {
 				// Metadata missing -> Orphaned sub-key -> Delete
@@ -174,13 +174,13 @@ mod tests {
 	use slatedb::ValueDeletable;
 
 	use super::*;
+	use crate::hash::field_key::HashFieldKey;
+	use crate::set::member_key::SetMemberKey;
 
 	#[tokio::test]
 	async fn test_collection_filter_version_mismatch() {
 		use std::sync::Arc;
 
-		use bytes::BufMut;
-		use bytes::BytesMut;
 		use slatedb::Db;
 		use slatedb::object_store::local::LocalFileSystem;
 		use slatedb::object_store::path::Path;
@@ -202,9 +202,7 @@ mod tests {
 		let user_key = Bytes::from("myhash");
 		let meta_key = MetaKey::new(user_key.clone());
 		let meta_val = HashMetaValue::new(10, 5);
-		db.put(Segment::Meta.wrap(meta_key.encode()), meta_val.encode())
-			.await
-			.unwrap();
+		db.put(meta_key.encode(), meta_val.encode()).await.unwrap();
 
 		// Setup Filter
 		let filter_db = Arc::new(OnceCell::new());
@@ -212,14 +210,9 @@ mod tests {
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
 		// Test valid version (10)
-		let mut valid_key = BytesMut::new();
-		valid_key.put_u16(user_key.len() as u16);
-		valid_key.extend_from_slice(&user_key);
-		valid_key.put_u64(10);
-		valid_key.put_u32(5); // field len
-		valid_key.put_slice(b"field");
+		let valid_key = HashFieldKey::new(user_key.clone(), 10, Bytes::from("field")).encode();
 		let valid_entry = RowEntry {
-			key: Segment::Hash.wrap(valid_key.freeze()),
+			key: valid_key,
 			value: ValueDeletable::Value(Bytes::from("val")),
 			seq: 1,
 			create_ts: None,
@@ -231,14 +224,9 @@ mod tests {
 		);
 
 		// Test stale version (9)
-		let mut invalid_key = BytesMut::new();
-		invalid_key.put_u16(user_key.len() as u16);
-		invalid_key.extend_from_slice(&user_key);
-		invalid_key.put_u64(9);
-		invalid_key.put_u32(5);
-		invalid_key.put_slice(b"field");
+		let invalid_key = HashFieldKey::new(user_key.clone(), 9, Bytes::from("field")).encode();
 		let invalid_entry = RowEntry {
-			key: Segment::Hash.wrap(invalid_key.freeze()),
+			key: invalid_key,
 			value: ValueDeletable::Value(Bytes::from("val")),
 			seq: 1,
 			create_ts: None,
@@ -254,8 +242,6 @@ mod tests {
 	async fn test_collection_filter_reclaims_orphaned_data() {
 		use std::sync::Arc;
 
-		use bytes::BufMut;
-		use bytes::BytesMut;
 		use slatedb::Db;
 		use slatedb::config::WriteOptions;
 		use slatedb::object_store::local::LocalFileSystem;
@@ -278,22 +264,14 @@ mod tests {
 		let user_key = Bytes::from("myset");
 		let meta_key = MetaKey::new(user_key.clone());
 		let meta_val = SetMetaValue::new(42, 3);
-		db.put(Segment::Meta.wrap(meta_key.encode()), meta_val.encode())
-			.await
-			.unwrap();
+		db.put(meta_key.encode(), meta_val.encode()).await.unwrap();
 
 		let filter_db = Arc::new(OnceCell::new());
 		let _ = filter_db.set(db.clone());
 		let mut filter = CollectionCompactionFilter { db: filter_db };
 
 		let build_sub_key = |version: u64, member: &[u8]| -> Bytes {
-			let mut key = BytesMut::new();
-			key.put_u16(user_key.len() as u16);
-			key.extend_from_slice(&user_key);
-			key.put_u64(version);
-			key.put_u32(member.len() as u32);
-			key.extend_from_slice(member);
-			Segment::Set.wrap(key.freeze())
+			SetMemberKey::new(user_key.clone(), version, Bytes::copy_from_slice(member)).encode()
 		};
 
 		let members: &[&[u8]] = &[b"alice", b"bob", b"carol"];
@@ -318,7 +296,7 @@ mod tests {
 			await_durable: false,
 			..WriteOptions::default()
 		};
-		db.delete_with_options(Segment::Meta.wrap(meta_key.encode()), &write_opts)
+		db.delete_with_options(meta_key.encode(), &write_opts)
 			.await
 			.unwrap();
 
@@ -341,7 +319,7 @@ mod tests {
 
 		// Simulate re-creation with new version: put meta with version=100
 		let new_meta_val = SetMetaValue::new(100, 1);
-		db.put(Segment::Meta.wrap(meta_key.encode()), new_meta_val.encode())
+		db.put(meta_key.encode(), new_meta_val.encode())
 			.await
 			.unwrap();
 

--- a/nimbis-storage/src/hash/field_key.rs
+++ b/nimbis-storage/src/hash/field_key.rs
@@ -5,29 +5,29 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct HashFieldKey {
 	user_key: Bytes,
-	generation: u64,
+	version: u64,
 	field: Bytes,
 }
 
 impl HashFieldKey {
-	pub fn new(user_key: impl Into<Bytes>, generation: u64, field: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, field: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
-			generation,
+			version,
 			field: field.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
 		// Key format:
-		// len(user_key) (u16 BE) + user_key + generation (u64 BE) + len(field) (u32 BE)
+		// len(user_key) (u16 BE) + user_key + version (u64 BE) + len(field) (u32 BE)
 		// + field
 		let field_len = self.field.len() as u32;
 
 		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.field.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
-		bytes.put_u64(self.generation);
+		bytes.put_u64(self.version);
 		bytes.put_u32(field_len);
 		bytes.extend_from_slice(&self.field);
 		bytes.freeze()
@@ -49,20 +49,20 @@ mod tests {
 	#[case("user", "field")]
 	#[case("key", "f")]
 	fn test_hash_field_key_encode(#[case] key: &str, #[case] field: &str) {
-		let generation = 0x0102_0304_0506_0708;
+		let version = 0x0102_0304_0506_0708;
 		let field_key = HashFieldKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
-			generation,
+			version,
 			Bytes::copy_from_slice(field.as_bytes()),
 		);
 		let encoded = field_key.encode();
-		// Verify format: key_len(u16) + key + generation(u64) + field_len(u32) + field
+		// Verify format: key_len(u16) + key + version(u64) + field_len(u32) + field
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
 		let version_start = 2 + key.len();
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
-			&generation.to_be_bytes()
+			&version.to_be_bytes()
 		);
 	}
 }

--- a/nimbis-storage/src/hash/field_key.rs
+++ b/nimbis-storage/src/hash/field_key.rs
@@ -2,6 +2,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 
+use crate::segment::HASH_PREFIX;
+
 #[derive(Debug, PartialEq)]
 pub struct HashFieldKey {
 	user_key: Bytes,
@@ -20,16 +22,27 @@ impl HashFieldKey {
 
 	pub fn encode(&self) -> Bytes {
 		// Key format:
-		// len(user_key) (u16 BE) + user_key + version (u64 BE) + len(field) (u32 BE)
-		// + field
+		// b'h' + len(user_key) (u16 BE) + user_key + version (u64 BE) +
+		// len(field) (u32 BE) + field
 		let field_len = self.field.len() as u32;
 
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.field.len());
+		let mut bytes =
+			BytesMut::with_capacity(1 + 2 + self.user_key.len() + 8 + 4 + self.field.len());
+		bytes.put_u8(HASH_PREFIX);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
 		bytes.put_u64(self.version);
 		bytes.put_u32(field_len);
 		bytes.extend_from_slice(&self.field);
+		bytes.freeze()
+	}
+
+	pub fn prefix(user_key: &Bytes, version: u64) -> Bytes {
+		let mut bytes = BytesMut::with_capacity(1 + 2 + user_key.len() + 8);
+		bytes.put_u8(HASH_PREFIX);
+		bytes.put_u16(user_key.len() as u16);
+		bytes.extend_from_slice(user_key);
+		bytes.put_u64(version);
 		bytes.freeze()
 	}
 
@@ -56,10 +69,12 @@ mod tests {
 			Bytes::copy_from_slice(field.as_bytes()),
 		);
 		let encoded = field_key.encode();
-		// Verify format: key_len(u16) + key + version(u64) + field_len(u32) + field
-		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
-		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
-		let version_start = 2 + key.len();
+		// Verify format: b'h' + key_len(u16) + key + version(u64) +
+		// field_len(u32) + field
+		assert_eq!(encoded[0], b'h');
+		assert_eq!(&encoded[1..3], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[3..3 + key.len()], key.as_bytes());
+		let version_start = 3 + key.len();
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
 			&version.to_be_bytes()

--- a/nimbis-storage/src/hash/field_key.rs
+++ b/nimbis-storage/src/hash/field_key.rs
@@ -5,24 +5,29 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct HashFieldKey {
 	user_key: Bytes,
+	generation: u64,
 	field: Bytes,
 }
 
 impl HashFieldKey {
-	pub fn new(user_key: impl Into<Bytes>, field: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, generation: u64, field: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			generation,
 			field: field.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + len(field) (u32 BE) + field
+		// Key format:
+		// len(user_key) (u16 BE) + user_key + generation (u64 BE) + len(field) (u32 BE)
+		// + field
 		let field_len = self.field.len() as u32;
 
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 4 + self.field.len());
+		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.field.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.generation);
 		bytes.put_u32(field_len);
 		bytes.extend_from_slice(&self.field);
 		bytes.freeze()
@@ -44,13 +49,20 @@ mod tests {
 	#[case("user", "field")]
 	#[case("key", "f")]
 	fn test_hash_field_key_encode(#[case] key: &str, #[case] field: &str) {
+		let generation = 0x0102_0304_0506_0708;
 		let field_key = HashFieldKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
+			generation,
 			Bytes::copy_from_slice(field.as_bytes()),
 		);
 		let encoded = field_key.encode();
-		// Verify format: key_len(u16) + key + field_len(u32) + field
+		// Verify format: key_len(u16) + key + generation(u64) + field_len(u32) + field
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let version_start = 2 + key.len();
+		assert_eq!(
+			&encoded[version_start..version_start + 8],
+			&generation.to_be_bytes()
+		);
 	}
 }

--- a/nimbis-storage/src/lib.rs
+++ b/nimbis-storage/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod hash;
 pub mod list;
 pub mod lock;
+pub mod segment;
 pub mod set;
 pub mod storage;
 pub mod storage_hash;

--- a/nimbis-storage/src/list/element_key.rs
+++ b/nimbis-storage/src/list/element_key.rs
@@ -5,26 +5,26 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct ListElementKey {
 	user_key: Bytes,
-	generation: u64,
+	version: u64,
 	seq: u64,
 }
 
 impl ListElementKey {
-	pub fn new(user_key: impl Into<Bytes>, generation: u64, seq: u64) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, seq: u64) -> Self {
 		Self {
 			user_key: user_key.into(),
-			generation,
+			version,
 			seq,
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + seq
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + seq
 		// (u64 BE)
 		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 8);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
-		bytes.put_u64(self.generation);
+		bytes.put_u64(self.version);
 		bytes.put_u64(self.seq);
 		bytes.freeze()
 	}
@@ -45,20 +45,19 @@ mod tests {
 	#[case("mykey", 100u64)]
 	#[case("key", 255u64)]
 	fn test_list_element_key_encode(#[case] key: &str, #[case] seq: u64) {
-		let generation = 0x0102_0304_0506_0708;
-		let element_key =
-			ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), generation, seq);
+		let version = 0x0102_0304_0506_0708;
+		let element_key = ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), version, seq);
 		let encoded = element_key.encode();
-		// Verify format: key_len(u16) + key + generation(u64) + seq(u64)
+		// Verify format: key_len(u16) + key + version(u64) + seq(u64)
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
-		let generation_start = 2 + key.len();
+		let version_start = 2 + key.len();
 		assert_eq!(
-			&encoded[generation_start..generation_start + 8],
-			&generation.to_be_bytes()
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
 		);
 		assert_eq!(
-			&encoded[generation_start + 8..generation_start + 16],
+			&encoded[version_start + 8..version_start + 16],
 			&seq.to_be_bytes()
 		);
 	}

--- a/nimbis-storage/src/list/element_key.rs
+++ b/nimbis-storage/src/list/element_key.rs
@@ -5,22 +5,26 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct ListElementKey {
 	user_key: Bytes,
+	generation: u64,
 	seq: u64,
 }
 
 impl ListElementKey {
-	pub fn new(user_key: impl Into<Bytes>, seq: u64) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, generation: u64, seq: u64) -> Self {
 		Self {
 			user_key: user_key.into(),
+			generation,
 			seq,
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + seq (u64 BE)
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8);
+		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + seq
+		// (u64 BE)
+		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 8);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.generation);
 		bytes.put_u64(self.seq);
 		bytes.freeze()
 	}
@@ -41,13 +45,20 @@ mod tests {
 	#[case("mykey", 100u64)]
 	#[case("key", 255u64)]
 	fn test_list_element_key_encode(#[case] key: &str, #[case] seq: u64) {
-		let element_key = ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), seq);
+		let generation = 0x0102_0304_0506_0708;
+		let element_key =
+			ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), generation, seq);
 		let encoded = element_key.encode();
-		// Verify format: key_len(u16) + key + seq(u64)
+		// Verify format: key_len(u16) + key + generation(u64) + seq(u64)
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let generation_start = 2 + key.len();
 		assert_eq!(
-			&encoded[2 + key.len()..2 + key.len() + 8],
+			&encoded[generation_start..generation_start + 8],
+			&generation.to_be_bytes()
+		);
+		assert_eq!(
+			&encoded[generation_start + 8..generation_start + 16],
 			&seq.to_be_bytes()
 		);
 	}

--- a/nimbis-storage/src/list/element_key.rs
+++ b/nimbis-storage/src/list/element_key.rs
@@ -2,6 +2,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 
+use crate::segment::LIST_PREFIX;
+
 #[derive(Debug, PartialEq)]
 pub struct ListElementKey {
 	user_key: Bytes,
@@ -19,9 +21,10 @@ impl ListElementKey {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + seq
-		// (u64 BE)
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 8 + 8);
+		// Key format: b'l' + len(user_key) (u16 BE) + user_key + version (u64 BE)
+		// + seq (u64 BE)
+		let mut bytes = BytesMut::with_capacity(1 + 2 + self.user_key.len() + 8 + 8);
+		bytes.put_u8(LIST_PREFIX);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
 		bytes.put_u64(self.version);
@@ -48,10 +51,11 @@ mod tests {
 		let version = 0x0102_0304_0506_0708;
 		let element_key = ListElementKey::new(Bytes::copy_from_slice(key.as_bytes()), version, seq);
 		let encoded = element_key.encode();
-		// Verify format: key_len(u16) + key + version(u64) + seq(u64)
-		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
-		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
-		let version_start = 2 + key.len();
+		// Verify format: b'l' + key_len(u16) + key + version(u64) + seq(u64)
+		assert_eq!(encoded[0], b'l');
+		assert_eq!(&encoded[1..3], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[3..3 + key.len()], key.as_bytes());
+		let version_start = 3 + key.len();
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
 			&version.to_be_bytes()

--- a/nimbis-storage/src/segment.rs
+++ b/nimbis-storage/src/segment.rs
@@ -1,40 +1,13 @@
-use bytes::Bytes;
-use bytes::BytesMut;
 use slatedb::PrefixExtractor;
 use slatedb::PrefixTarget;
 
 pub const EXTRACTOR_NAME: &str = "nimbis-storage-segment-v1";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum Segment {
-	Internal = 0,
-	Meta = b'm',
-	Hash = b'h',
-	List = b'l',
-	Set = b'S',
-	ZSet = b'z',
-}
-
-impl Segment {
-	pub fn prefix(self) -> u8 {
-		self as u8
-	}
-
-	pub fn wrap(self, payload: Bytes) -> Bytes {
-		let mut key = BytesMut::with_capacity(1 + payload.len());
-		key.extend_from_slice(&[self.prefix()]);
-		key.extend_from_slice(&payload);
-		key.freeze()
-	}
-
-	pub fn strip(self, encoded: &Bytes) -> Option<Bytes> {
-		if encoded.first().copied()? != self.prefix() {
-			return None;
-		}
-		Some(encoded.slice(1..))
-	}
-}
+pub const META_PREFIX: u8 = b'm';
+pub const HASH_PREFIX: u8 = b'h';
+pub const LIST_PREFIX: u8 = b'l';
+pub const SET_PREFIX: u8 = b'S';
+pub const ZSET_PREFIX: u8 = b'z';
 
 #[derive(Debug, Default)]
 pub struct NimbisSegmentExtractor;

--- a/nimbis-storage/src/segment.rs
+++ b/nimbis-storage/src/segment.rs
@@ -1,0 +1,53 @@
+use bytes::Bytes;
+use bytes::BytesMut;
+use slatedb::PrefixExtractor;
+use slatedb::PrefixTarget;
+
+pub const EXTRACTOR_NAME: &str = "nimbis-storage-segment-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Segment {
+	Internal = 0,
+	Meta = b'm',
+	Hash = b'h',
+	List = b'l',
+	Set = b'S',
+	ZSet = b'z',
+}
+
+impl Segment {
+	pub fn prefix(self) -> u8 {
+		self as u8
+	}
+
+	pub fn wrap(self, payload: Bytes) -> Bytes {
+		let mut key = BytesMut::with_capacity(1 + payload.len());
+		key.extend_from_slice(&[self.prefix()]);
+		key.extend_from_slice(&payload);
+		key.freeze()
+	}
+
+	pub fn strip(self, encoded: &Bytes) -> Option<Bytes> {
+		if encoded.first().copied()? != self.prefix() {
+			return None;
+		}
+		Some(encoded.slice(1..))
+	}
+}
+
+#[derive(Debug, Default)]
+pub struct NimbisSegmentExtractor;
+
+impl PrefixExtractor for NimbisSegmentExtractor {
+	fn name(&self) -> &str {
+		EXTRACTOR_NAME
+	}
+
+	fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+		let bytes = match target {
+			PrefixTarget::Point(bytes) | PrefixTarget::Prefix(bytes) => bytes,
+		};
+		(!bytes.is_empty()).then_some(1)
+	}
+}

--- a/nimbis-storage/src/set/member_key.rs
+++ b/nimbis-storage/src/set/member_key.rs
@@ -5,22 +5,22 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct SetMemberKey {
 	user_key: Bytes,
-	generation: u64,
+	version: u64,
 	member: Bytes,
 }
 
 impl SetMemberKey {
-	pub fn new(user_key: impl Into<Bytes>, generation: u64, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
-			generation,
+			version,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
 		// Key format:
-		// len(user_key) (u16 BE) + user_key + generation (u64 BE) + len(member) (u32
+		// len(user_key) (u16 BE) + user_key + version (u64 BE) + len(member) (u32
 		// BE) + member
 		let member_len = self.member.len() as u32;
 
@@ -28,7 +28,7 @@ impl SetMemberKey {
 			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.member.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
-		bytes.put_u64(self.generation);
+		bytes.put_u64(self.version);
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
 		bytes.freeze()
@@ -50,21 +50,21 @@ mod tests {
 	#[case("user", "member")]
 	#[case("key", "m")]
 	fn test_set_member_key_encode(#[case] key: &str, #[case] member: &str) {
-		let generation = 0x0102_0304_0506_0708;
+		let version = 0x0102_0304_0506_0708;
 		let member_key = SetMemberKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
-			generation,
+			version,
 			Bytes::copy_from_slice(member.as_bytes()),
 		);
 		let encoded = member_key.encode();
-		// Verify format: key_len(u16) + key + generation(u64) + member_len(u32) +
+		// Verify format: key_len(u16) + key + version(u64) + member_len(u32) +
 		// member
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
-		let generation_start = 2 + key.len();
+		let version_start = 2 + key.len();
 		assert_eq!(
-			&encoded[generation_start..generation_start + 8],
-			&generation.to_be_bytes()
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
 		);
 	}
 }

--- a/nimbis-storage/src/set/member_key.rs
+++ b/nimbis-storage/src/set/member_key.rs
@@ -5,24 +5,30 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct SetMemberKey {
 	user_key: Bytes,
+	generation: u64,
 	member: Bytes,
 }
 
 impl SetMemberKey {
-	pub fn new(user_key: impl Into<Bytes>, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, generation: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			generation,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + len(member) (u32 BE) + member
+		// Key format:
+		// len(user_key) (u16 BE) + user_key + generation (u64 BE) + len(member) (u32
+		// BE) + member
 		let member_len = self.member.len() as u32;
 
-		let mut bytes = BytesMut::with_capacity(2 + self.user_key.len() + 4 + self.member.len());
+		let mut bytes =
+			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.member.len());
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.generation);
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
 		bytes.freeze()
@@ -44,13 +50,21 @@ mod tests {
 	#[case("user", "member")]
 	#[case("key", "m")]
 	fn test_set_member_key_encode(#[case] key: &str, #[case] member: &str) {
+		let generation = 0x0102_0304_0506_0708;
 		let member_key = SetMemberKey::new(
 			Bytes::copy_from_slice(key.as_bytes()),
+			generation,
 			Bytes::copy_from_slice(member.as_bytes()),
 		);
 		let encoded = member_key.encode();
-		// Verify format: key_len(u16) + key + member_len(u32) + member
+		// Verify format: key_len(u16) + key + generation(u64) + member_len(u32) +
+		// member
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
+		let generation_start = 2 + key.len();
+		assert_eq!(
+			&encoded[generation_start..generation_start + 8],
+			&generation.to_be_bytes()
+		);
 	}
 }

--- a/nimbis-storage/src/set/member_key.rs
+++ b/nimbis-storage/src/set/member_key.rs
@@ -2,6 +2,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 
+use crate::segment::SET_PREFIX;
+
 #[derive(Debug, PartialEq)]
 pub struct SetMemberKey {
 	user_key: Bytes,
@@ -20,17 +22,35 @@ impl SetMemberKey {
 
 	pub fn encode(&self) -> Bytes {
 		// Key format:
-		// len(user_key) (u16 BE) + user_key + version (u64 BE) + len(member) (u32
-		// BE) + member
+		// b'S' + len(user_key) (u16 BE) + user_key + version (u64 BE) +
+		// len(member) (u32 BE) + member
 		let member_len = self.member.len() as u32;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 4 + self.member.len());
+			BytesMut::with_capacity(1 + 2 + self.user_key.len() + 8 + 4 + self.member.len());
+		bytes.put_u8(SET_PREFIX);
 		bytes.put_u16(self.user_key.len() as u16);
 		bytes.extend_from_slice(&self.user_key);
 		bytes.put_u64(self.version);
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
+		bytes.freeze()
+	}
+
+	pub fn prefix(user_key: &Bytes, version: u64) -> Bytes {
+		let mut bytes = BytesMut::with_capacity(1 + 2 + user_key.len() + 8);
+		bytes.put_u8(SET_PREFIX);
+		bytes.put_u16(user_key.len() as u16);
+		bytes.extend_from_slice(user_key);
+		bytes.put_u64(version);
+		bytes.freeze()
+	}
+
+	pub fn user_prefix(user_key: &Bytes) -> Bytes {
+		let mut bytes = BytesMut::with_capacity(1 + 2 + user_key.len());
+		bytes.put_u8(SET_PREFIX);
+		bytes.put_u16(user_key.len() as u16);
+		bytes.extend_from_slice(user_key);
 		bytes.freeze()
 	}
 
@@ -57,11 +77,12 @@ mod tests {
 			Bytes::copy_from_slice(member.as_bytes()),
 		);
 		let encoded = member_key.encode();
-		// Verify format: key_len(u16) + key + version(u64) + member_len(u32) +
-		// member
-		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
-		assert_eq!(&encoded[2..2 + key.len()], key.as_bytes());
-		let version_start = 2 + key.len();
+		// Verify format: b'S' + key_len(u16) + key + version(u64) +
+		// member_len(u32) + member
+		assert_eq!(encoded[0], b'S');
+		assert_eq!(&encoded[1..3], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[3..3 + key.len()], key.as_bytes());
+		let version_start = 3 + key.len();
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
 			&version.to_be_bytes()

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -119,7 +119,7 @@ impl Storage {
 		}
 	}
 
-	pub(crate) fn next_generation(&self) -> u64 {
+	pub(crate) fn next_version(&self) -> u64 {
 		self.version_generator.next()
 	}
 

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -22,7 +22,6 @@ use crate::lock::StorageLock;
 use crate::lock::StorageLockGuard;
 use crate::lock::StorageLocks;
 use crate::segment::NimbisSegmentExtractor;
-use crate::segment::Segment;
 use crate::string::meta::MetaKey;
 use crate::string::meta::MetaValue;
 use crate::utils::is_expired;
@@ -255,7 +254,7 @@ impl Storage {
 		key: &Bytes,
 	) -> Result<Option<T>, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 		let kv = match self.db.get_key_value(meta_encoded_key.clone()).await? {
 			Some(kv) => kv,
 			None => return Ok(None),
@@ -331,7 +330,6 @@ mod tests {
 	#[tokio::test]
 	async fn hset_writes_meta_and_field_in_one_segmented_batch(#[future] ctx: TestContext) {
 		use crate::hash::field_key::HashFieldKey;
-		use crate::segment::Segment;
 		use crate::string::meta::HashMetaValue;
 
 		let ctx = ctx.await;
@@ -346,7 +344,7 @@ mod tests {
 			.unwrap();
 		assert_eq!(added, 1);
 
-		let meta_key = Segment::Meta.wrap(MetaKey::new(key.clone()).encode());
+		let meta_key = MetaKey::new(key.clone()).encode();
 
 		let meta_entry = ctx
 			.storage
@@ -358,7 +356,7 @@ mod tests {
 		let meta = HashMetaValue::decode(&meta_entry.value).unwrap();
 		assert!(meta.version > 0);
 
-		let field_key = Segment::Hash.wrap(HashFieldKey::new(key, meta.version, field).encode());
+		let field_key = HashFieldKey::new(key, meta.version, field).encode();
 		let field_entry = ctx
 			.storage
 			.db
@@ -373,7 +371,7 @@ mod tests {
 	#[rstest]
 	#[tokio::test]
 	async fn string_set_does_not_write_internal_seq_or_collection_keys(#[future] ctx: TestContext) {
-		use crate::segment::Segment;
+		use crate::segment::META_PREFIX;
 
 		let ctx = ctx.await;
 		ctx.storage
@@ -387,7 +385,7 @@ mod tests {
 			seen.push(kv.key.first().copied());
 		}
 
-		assert_eq!(seen, vec![Some(Segment::Meta.prefix())]);
+		assert_eq!(seen, vec![Some(META_PREFIX)]);
 	}
 
 	#[rstest]
@@ -457,9 +455,7 @@ mod tests {
 		use slatedb::CompactionFilter;
 
 		use crate::compaction_filter::CollectionCompactionFilter;
-		use crate::segment::Segment;
-		use crate::utils::user_key_prefix;
-
+		use crate::set::member_key::SetMemberKey;
 		let ctx = ctx.await;
 		let key = Bytes::from("leak_test_set");
 
@@ -487,7 +483,7 @@ mod tests {
 		assert!(!exists);
 
 		// KEY VERIFICATION: Scan raw set segment to prove physical data still exists
-		let prefix = Segment::Set.wrap(user_key_prefix(&key));
+		let prefix = SetMemberKey::user_prefix(&key);
 		let mut stream = ctx.storage.db.scan(prefix.clone()..).await.unwrap();
 		let mut raw_count = 0;
 		let mut raw_entries = Vec::new();

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -34,6 +34,8 @@ pub struct Storage {
 	locks: Arc<StorageLocks>,
 }
 
+const FLUSH_BATCH_SIZE: usize = 1024;
+
 fn shard_path(base_path: ObjectStorePath, shard_id: Option<usize>) -> ObjectStorePath {
 	match shard_id {
 		Some(id) => base_path.join(format!("shard-{}", id)),
@@ -200,7 +202,10 @@ impl Storage {
 			.await
 			.map_err(StorageError::from)?;
 		let db = Arc::new(db);
-		let _ = filter_db.set(db.clone());
+		assert!(
+			filter_db.set(db.clone()).is_ok(),
+			"compaction filter DB handle should only be initialized once"
+		);
 
 		Ok(Self::new(db))
 	}
@@ -230,13 +235,19 @@ impl Storage {
 	pub async fn flush_all(&self) -> Result<(), StorageError> {
 		let mut stream = self.db.scan::<Bytes, _>(..).await?;
 		let mut batch = WriteBatch::new();
-		let mut has_deletes = false;
+		let mut batch_len = 0;
 		while let Some(kv) = stream.next().await? {
 			batch.delete(kv.key);
-			has_deletes = true;
+			batch_len += 1;
+
+			if batch_len >= FLUSH_BATCH_SIZE {
+				let batch_to_write = std::mem::replace(&mut batch, WriteBatch::new());
+				self.write_batch(batch_to_write).await?;
+				batch_len = 0;
+			}
 		}
 
-		if has_deletes {
+		if batch_len > 0 {
 			self.write_batch(batch).await?;
 		}
 
@@ -386,6 +397,27 @@ mod tests {
 		}
 
 		assert_eq!(seen, vec![Some(META_PREFIX)]);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn flush_all_handles_more_than_one_delete_batch(#[future] ctx: TestContext) {
+		let ctx = ctx.await;
+
+		for i in 0..=FLUSH_BATCH_SIZE {
+			ctx.storage
+				.set(
+					Bytes::from(format!("flush_key_{i}")),
+					Bytes::from_static(b"value"),
+				)
+				.await
+				.unwrap();
+		}
+
+		ctx.storage.flush_all().await.unwrap();
+
+		let mut stream = ctx.storage.db.scan::<Bytes, _>(..).await.unwrap();
+		assert!(stream.next().await.unwrap().is_none());
 	}
 
 	#[rstest]

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -1,16 +1,22 @@
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
 use nimbis_macros::storage_lock;
 use slatedb::Db;
+use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
 use slatedb::config::WriteOptions;
 use slatedb::db_cache::foyer::FoyerCache;
 use slatedb::object_store::ObjectStore;
+use slatedb::object_store::ObjectStoreExt;
 use slatedb::object_store::ObjectStoreScheme;
 use slatedb::object_store::local::LocalFileSystem;
 use slatedb::object_store::parse_url_opts;
 use slatedb::object_store::path::Path as ObjectStorePath;
+use tokio::sync::Mutex;
+use tokio::sync::OnceCell;
 
 use crate::compaction_filter::CollectionCompactionFilterSupplier;
 use crate::data_type::DataType;
@@ -18,23 +24,25 @@ use crate::error::StorageError;
 use crate::lock::StorageLock;
 use crate::lock::StorageLockGuard;
 use crate::lock::StorageLocks;
+use crate::segment::NimbisSegmentExtractor;
+use crate::segment::Segment;
 use crate::string::meta::MetaKey;
 use crate::string::meta::MetaValue;
 use crate::utils::is_expired;
 
 #[derive(Clone)]
 pub struct Storage {
-	pub(crate) string_db: Arc<Db>,
-	pub(crate) hash_db: Arc<Db>,
-	pub(crate) list_db: Arc<Db>,
-	pub(crate) set_db: Arc<Db>,
-	pub(crate) zset_db: Arc<Db>,
+	pub(crate) db: Arc<Db>,
+	next_seq: Arc<AtomicU64>,
+	seq_write_lock: Arc<Mutex<()>>,
 	locks: Arc<StorageLocks>,
 }
 
+const INTERNAL_SEQ_KEY: &[u8] = b"seq";
+
 fn shard_path(base_path: ObjectStorePath, shard_id: Option<usize>) -> ObjectStorePath {
 	match shard_id {
-		Some(id) => base_path.child(format!("shard-{}", id)),
+		Some(id) => base_path.join(format!("shard-{}", id)),
 		None => base_path,
 	}
 }
@@ -108,19 +116,11 @@ where
 }
 
 impl Storage {
-	pub fn new(
-		string_db: Arc<Db>,
-		hash_db: Arc<Db>,
-		list_db: Arc<Db>,
-		set_db: Arc<Db>,
-		zset_db: Arc<Db>,
-	) -> Self {
+	pub fn new(db: Arc<Db>, last_seq: u64) -> Self {
 		Self {
-			string_db,
-			hash_db,
-			list_db,
-			set_db,
-			zset_db,
+			db,
+			next_seq: Arc::new(AtomicU64::new(last_seq)),
+			seq_write_lock: Arc::new(Mutex::new(())),
 			locks: Arc::new(StorageLocks::new()),
 		}
 	}
@@ -178,7 +178,7 @@ impl Storage {
 		object_store: Arc<dyn ObjectStore>,
 		root_path: ObjectStorePath,
 	) -> Result<Self, StorageError> {
-		let child_path = |name: &'static str| root_path.child(name);
+		let child_path = |name: &'static str| root_path.clone().join(name);
 
 		let marker = child_path(".nimbis");
 		object_store
@@ -186,100 +186,95 @@ impl Storage {
 			.await
 			.map_err(StorageError::from)?;
 
-		// Create a single shared cache for all databases in this shard
 		let cache = Arc::new(FoyerCache::new());
+		let db_path = child_path("db");
+		let filter_db = Arc::new(OnceCell::new());
+		let compactor_builder =
+			slatedb::CompactorBuilder::new(db_path.clone(), object_store.clone())
+				.with_compaction_filter_supplier(Arc::new(CollectionCompactionFilterSupplier {
+					db: filter_db.clone(),
+				}));
 
-		// Open string_db — no custom compaction filter needed;
-		// SlateDB's built-in TTL mechanism handles expiration during compaction.
-		let string_db = {
-			let db_path = child_path("string");
-			let db = Db::builder(db_path, object_store.clone())
-				.with_db_cache(cache.clone())
-				.build()
-				.await
-				.map_err(StorageError::from)?;
-			Arc::new(db)
-		};
+		let db = Db::builder(db_path, object_store)
+			.with_db_cache(cache)
+			.with_segment_extractor(Arc::new(NimbisSegmentExtractor))
+			.with_compactor_builder(compactor_builder)
+			.build()
+			.await
+			.map_err(StorageError::from)?;
+		let db = Arc::new(db);
+		let _ = filter_db.set(db.clone());
+		let last_seq = Self::load_last_seq(&db).await?;
 
-		// Open collection DBs with CollectionCompactionFilter referencing string_db
-		let open_db_with_collection_filter = |name: &'static str, data_type: DataType| {
-			let store = object_store.clone();
-			let cache = cache.clone();
-			let string_db = string_db.clone();
-			let db_path = child_path(name);
-			async move {
-				let compactor_builder =
-					slatedb::CompactorBuilder::new(db_path.clone(), store.clone())
-						.with_compaction_filter_supplier(Arc::new(
-							CollectionCompactionFilterSupplier {
-								string_db,
-								data_type,
-							},
-						));
-				let db: Result<Db, slatedb::Error> = Db::builder(db_path, store)
-					.with_db_cache(cache)
-					.with_compactor_builder(compactor_builder)
-					.build()
-					.await;
-				db.map_err(StorageError::from)
-			}
-		};
-
-		let (hash_db, list_db, set_db, zset_db) = tokio::try_join!(
-			open_db_with_collection_filter("hash", DataType::Hash),
-			open_db_with_collection_filter("list", DataType::List),
-			open_db_with_collection_filter("set", DataType::Set),
-			open_db_with_collection_filter("zset", DataType::ZSet)
-		)?;
-
-		Ok(Self::new(
-			string_db,
-			Arc::new(hash_db),
-			Arc::new(list_db),
-			Arc::new(set_db),
-			Arc::new(zset_db),
-		))
+		Ok(Self::new(db, last_seq))
 	}
 
 	pub async fn close(&self) -> Result<(), StorageError> {
-		tokio::try_join!(
-			self.hash_db.close(),
-			self.list_db.close(),
-			self.set_db.close(),
-			self.zset_db.close(),
-		)?;
-		self.string_db.close().await?;
+		self.db.close().await?;
 		Ok(())
+	}
+
+	pub(crate) fn internal_seq_key() -> Bytes {
+		Segment::Internal.wrap(Bytes::from_static(INTERNAL_SEQ_KEY))
+	}
+
+	async fn load_last_seq(db: &Db) -> Result<u64, StorageError> {
+		let Some(value) = db.get(Self::internal_seq_key()).await? else {
+			return Ok(0);
+		};
+		let bytes: [u8; 8] = value[..].try_into()?;
+		Ok(u64::from_be_bytes(bytes))
+	}
+
+	pub(crate) fn write_opts(seq: u64) -> WriteOptions {
+		WriteOptions {
+			await_durable: false,
+			seqnum: seq,
+		}
+	}
+
+	fn next_write_seq(&self) -> u64 {
+		self.next_seq.fetch_add(1, Ordering::SeqCst) + 1
+	}
+
+	pub(crate) async fn write_batch_with_seq<F>(&self, build_batch: F) -> Result<u64, StorageError>
+	where
+		F: FnOnce(u64) -> WriteBatch,
+	{
+		let _guard = self.seq_write_lock.lock().await;
+		let seq = self.next_write_seq();
+		let mut batch = build_batch(seq);
+		batch.put(
+			Self::internal_seq_key(),
+			Bytes::copy_from_slice(&seq.to_be_bytes()),
+		);
+		self.db
+			.write_with_options(batch, &Self::write_opts(seq))
+			.await?;
+		Ok(seq)
+	}
+
+	pub(crate) async fn write_batch(&self, batch: WriteBatch) -> Result<u64, StorageError> {
+		self.write_batch_with_seq(|_| batch).await
 	}
 
 	#[storage_lock(global_write)]
 	#[fastrace::trace]
 	pub async fn flush_all(&self) -> Result<(), StorageError> {
-		// Iterate over all DBs and delete all keys
-		// Since we don't have atomic flush_all, we do best effort sequential
-		// Scanning and deleting everything is slow but correct for tests.
-		// For production this is blocking and bad, but it's FLUSHDB.
-
-		// Helper to clear a DB
-		async fn clear_db(
-			db: &slatedb::Db,
-		) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-			let scan_range = ..;
-			let mut stream = db.scan::<bytes::Bytes, _>(scan_range).await?;
-			let write_opts = slatedb::config::WriteOptions {
-				await_durable: false,
-			};
-			while let Some(kv) = stream.next().await? {
-				db.delete_with_options(kv.key, &write_opts).await?;
+		let mut stream = self.db.scan::<Bytes, _>(..).await?;
+		let mut batch = WriteBatch::new();
+		let mut has_deletes = false;
+		while let Some(kv) = stream.next().await? {
+			if kv.key.first().copied() == Some(Segment::Internal.prefix()) {
+				continue;
 			}
-			Ok(())
+			batch.delete(kv.key);
+			has_deletes = true;
 		}
 
-		clear_db(&self.string_db).await?;
-		clear_db(&self.hash_db).await?;
-		clear_db(&self.list_db).await?;
-		clear_db(&self.set_db).await?;
-		clear_db(&self.zset_db).await?;
+		if has_deletes {
+			self.write_batch(batch).await?;
+		}
 
 		Ok(())
 	}
@@ -295,23 +290,16 @@ impl Storage {
 		key: &Bytes,
 	) -> Result<Option<T>, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
-		let kv = match self
-			.string_db
-			.get_key_value(meta_encoded_key.clone())
-			.await?
-		{
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let kv = match self.db.get_key_value(meta_encoded_key.clone()).await? {
 			Some(kv) => kv,
 			None => return Ok(None),
 		};
 
 		if is_expired(kv.expire_ts) {
-			let write_opts = WriteOptions {
-				await_durable: false,
-			};
-			self.string_db
-				.delete_with_options(meta_encoded_key, &write_opts)
-				.await?;
+			let mut batch = WriteBatch::new();
+			batch.delete(meta_encoded_key);
+			self.write_batch(batch).await?;
 			return Ok(None);
 		}
 
@@ -372,6 +360,49 @@ mod tests {
 		std::fs::create_dir_all(&path).unwrap();
 		let storage = Storage::open(&path, None).await.unwrap();
 		TestContext { storage, path }
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn hset_writes_meta_and_field_in_one_segmented_batch(#[future] ctx: TestContext) {
+		use crate::hash::field_key::HashFieldKey;
+		use crate::segment::Segment;
+		use crate::string::meta::HashMetaValue;
+
+		let ctx = ctx.await;
+		let key = Bytes::from("segmented_hash");
+		let field = Bytes::from("field");
+		let value = Bytes::from("value");
+
+		let added = ctx
+			.storage
+			.hset(key.clone(), field.clone(), value.clone())
+			.await
+			.unwrap();
+		assert_eq!(added, 1);
+
+		let meta_key = Segment::Meta.wrap(MetaKey::new(key.clone()).encode());
+		let field_key = Segment::Hash.wrap(HashFieldKey::new(key, field).encode());
+
+		let meta_entry = ctx
+			.storage
+			.db
+			.get_key_value(meta_key)
+			.await
+			.unwrap()
+			.unwrap();
+		let field_entry = ctx
+			.storage
+			.db
+			.get_key_value(field_key)
+			.await
+			.unwrap()
+			.unwrap();
+
+		let meta = HashMetaValue::decode(&meta_entry.value).unwrap();
+		assert_eq!(meta.version, meta_entry.seq);
+		assert_eq!(meta_entry.seq, field_entry.seq);
+		assert_eq!(field_entry.value, value);
 	}
 
 	#[rstest]
@@ -441,7 +472,8 @@ mod tests {
 		use slatedb::CompactionFilter;
 
 		use crate::compaction_filter::CollectionCompactionFilter;
-		use crate::data_type::DataType;
+		use crate::segment::Segment;
+		use crate::utils::user_key_prefix;
 
 		let ctx = ctx.await;
 		let key = Bytes::from("leak_test_set");
@@ -469,17 +501,15 @@ mod tests {
 		let exists = ctx.storage.exists(key.clone()).await.unwrap();
 		assert!(!exists);
 
-		// KEY VERIFICATION: Scan raw set_db to prove physical data still exists
-		let scan_range = ..;
-		let mut stream = ctx
-			.storage
-			.set_db
-			.scan::<Bytes, _>(scan_range)
-			.await
-			.unwrap();
+		// KEY VERIFICATION: Scan raw set segment to prove physical data still exists
+		let prefix = Segment::Set.wrap(user_key_prefix(&key));
+		let mut stream = ctx.storage.db.scan(prefix.clone()..).await.unwrap();
 		let mut raw_count = 0;
 		let mut raw_entries = Vec::new();
 		while let Some(kv) = stream.next().await.unwrap() {
+			if !kv.key.starts_with(&prefix) {
+				break;
+			}
 			raw_count += 1;
 			raw_entries.push(kv);
 		}
@@ -491,17 +521,16 @@ mod tests {
 		);
 
 		// Run compaction filter logic on all raw entries
-		let mut filter = CollectionCompactionFilter {
-			string_db: ctx.storage.string_db.clone(),
-			data_type: DataType::Set,
-		};
+		let filter_db = Arc::new(OnceCell::new());
+		let _ = filter_db.set(ctx.storage.db.clone());
+		let mut filter = CollectionCompactionFilter { db: filter_db };
 
 		let mut reclaimed_count = 0;
 		for kv in &raw_entries {
 			let entry = slatedb::RowEntry {
 				key: kv.key.clone(),
 				value: slatedb::ValueDeletable::Value(kv.value.clone()),
-				seq: 0,
+				seq: kv.seq,
 				create_ts: None,
 				expire_ts: None,
 			};

--- a/nimbis-storage/src/storage.rs
+++ b/nimbis-storage/src/storage.rs
@@ -1,6 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
 use bytes::Bytes;
 use nimbis_macros::storage_lock;
@@ -15,7 +13,6 @@ use slatedb::object_store::ObjectStoreScheme;
 use slatedb::object_store::local::LocalFileSystem;
 use slatedb::object_store::parse_url_opts;
 use slatedb::object_store::path::Path as ObjectStorePath;
-use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
 
 use crate::compaction_filter::CollectionCompactionFilterSupplier;
@@ -29,16 +26,14 @@ use crate::segment::Segment;
 use crate::string::meta::MetaKey;
 use crate::string::meta::MetaValue;
 use crate::utils::is_expired;
+use crate::version::VersionGenerator;
 
 #[derive(Clone)]
 pub struct Storage {
 	pub(crate) db: Arc<Db>,
-	next_seq: Arc<AtomicU64>,
-	seq_write_lock: Arc<Mutex<()>>,
+	version_generator: Arc<VersionGenerator>,
 	locks: Arc<StorageLocks>,
 }
-
-const INTERNAL_SEQ_KEY: &[u8] = b"seq";
 
 fn shard_path(base_path: ObjectStorePath, shard_id: Option<usize>) -> ObjectStorePath {
 	match shard_id {
@@ -116,13 +111,16 @@ where
 }
 
 impl Storage {
-	pub fn new(db: Arc<Db>, last_seq: u64) -> Self {
+	pub fn new(db: Arc<Db>) -> Self {
 		Self {
 			db,
-			next_seq: Arc::new(AtomicU64::new(last_seq)),
-			seq_write_lock: Arc::new(Mutex::new(())),
+			version_generator: Arc::new(VersionGenerator::new()),
 			locks: Arc::new(StorageLocks::new()),
 		}
+	}
+
+	pub(crate) fn next_generation(&self) -> u64 {
+		self.version_generator.next()
 	}
 
 	pub(crate) async fn read_lock(
@@ -204,9 +202,8 @@ impl Storage {
 			.map_err(StorageError::from)?;
 		let db = Arc::new(db);
 		let _ = filter_db.set(db.clone());
-		let last_seq = Self::load_last_seq(&db).await?;
 
-		Ok(Self::new(db, last_seq))
+		Ok(Self::new(db))
 	}
 
 	pub async fn close(&self) -> Result<(), StorageError> {
@@ -214,48 +211,19 @@ impl Storage {
 		Ok(())
 	}
 
-	pub(crate) fn internal_seq_key() -> Bytes {
-		Segment::Internal.wrap(Bytes::from_static(INTERNAL_SEQ_KEY))
-	}
-
-	async fn load_last_seq(db: &Db) -> Result<u64, StorageError> {
-		let Some(value) = db.get(Self::internal_seq_key()).await? else {
-			return Ok(0);
-		};
-		let bytes: [u8; 8] = value[..].try_into()?;
-		Ok(u64::from_be_bytes(bytes))
-	}
-
-	pub(crate) fn write_opts(seq: u64) -> WriteOptions {
+	pub(crate) fn write_opts() -> WriteOptions {
 		WriteOptions {
 			await_durable: false,
-			seqnum: seq,
+			..WriteOptions::default()
 		}
 	}
 
-	fn next_write_seq(&self) -> u64 {
-		self.next_seq.fetch_add(1, Ordering::SeqCst) + 1
-	}
-
-	pub(crate) async fn write_batch_with_seq<F>(&self, build_batch: F) -> Result<u64, StorageError>
-	where
-		F: FnOnce(u64) -> WriteBatch,
-	{
-		let _guard = self.seq_write_lock.lock().await;
-		let seq = self.next_write_seq();
-		let mut batch = build_batch(seq);
-		batch.put(
-			Self::internal_seq_key(),
-			Bytes::copy_from_slice(&seq.to_be_bytes()),
-		);
-		self.db
-			.write_with_options(batch, &Self::write_opts(seq))
-			.await?;
-		Ok(seq)
-	}
-
 	pub(crate) async fn write_batch(&self, batch: WriteBatch) -> Result<u64, StorageError> {
-		self.write_batch_with_seq(|_| batch).await
+		let handle = self
+			.db
+			.write_with_options(batch, &Self::write_opts())
+			.await?;
+		Ok(handle.seqnum())
 	}
 
 	#[storage_lock(global_write)]
@@ -265,9 +233,6 @@ impl Storage {
 		let mut batch = WriteBatch::new();
 		let mut has_deletes = false;
 		while let Some(kv) = stream.next().await? {
-			if kv.key.first().copied() == Some(Segment::Internal.prefix()) {
-				continue;
-			}
 			batch.delete(kv.key);
 			has_deletes = true;
 		}
@@ -382,7 +347,6 @@ mod tests {
 		assert_eq!(added, 1);
 
 		let meta_key = Segment::Meta.wrap(MetaKey::new(key.clone()).encode());
-		let field_key = Segment::Hash.wrap(HashFieldKey::new(key, field).encode());
 
 		let meta_entry = ctx
 			.storage
@@ -391,6 +355,10 @@ mod tests {
 			.await
 			.unwrap()
 			.unwrap();
+		let meta = HashMetaValue::decode(&meta_entry.value).unwrap();
+		assert!(meta.version > 0);
+
+		let field_key = Segment::Hash.wrap(HashFieldKey::new(key, meta.version, field).encode());
 		let field_entry = ctx
 			.storage
 			.db
@@ -399,10 +367,27 @@ mod tests {
 			.unwrap()
 			.unwrap();
 
-		let meta = HashMetaValue::decode(&meta_entry.value).unwrap();
-		assert_eq!(meta.version, meta_entry.seq);
-		assert_eq!(meta_entry.seq, field_entry.seq);
 		assert_eq!(field_entry.value, value);
+	}
+
+	#[rstest]
+	#[tokio::test]
+	async fn string_set_does_not_write_internal_seq_or_collection_keys(#[future] ctx: TestContext) {
+		use crate::segment::Segment;
+
+		let ctx = ctx.await;
+		ctx.storage
+			.set(Bytes::from("plain_string"), Bytes::from("value"))
+			.await
+			.unwrap();
+
+		let mut stream = ctx.storage.db.scan::<Bytes, _>(..).await.unwrap();
+		let mut seen = Vec::new();
+		while let Some(kv) = stream.next().await.unwrap() {
+			seen.push(kv.key.first().copied());
+		}
+
+		assert_eq!(seen, vec![Some(Segment::Meta.prefix())]);
 	}
 
 	#[rstest]

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -2,11 +2,12 @@ use bytes::Buf;
 use bytes::Bytes;
 use futures::future;
 use nimbis_macros::storage_lock;
+use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
-use slatedb::config::WriteOptions;
 
 use crate::error::StorageError;
 use crate::hash::field_key::HashFieldKey;
+use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::HashMetaValue;
 use crate::string::meta::MetaKey;
@@ -17,56 +18,49 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn hset(&self, key: Bytes, field: Bytes, value: Bytes) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
 		// Now create field key with the version from metadata
 		let field_key = HashFieldKey::new(key.clone(), field);
-		let encoded_field_key = field_key.encode();
+		let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 
-		let Some(mut meta_val) = self.get_meta::<HashMetaValue>(&key).await? else {
-			let wh = self
-				.hash_db
-				.put_with_options(encoded_field_key, value, &put_opts, &write_opts)
-				.await?;
+		let meta_val = self.get_meta::<HashMetaValue>(&key).await?;
 
-			let new_meta = HashMetaValue::new(wh.seqnum(), 1);
-			self.string_db
-				.put_with_options(meta_encoded_key, new_meta.encode(), &put_opts, &write_opts)
-				.await?;
+		let Some(mut meta_val) = meta_val else {
+			self.write_batch_with_seq(|seq| {
+				let mut batch = WriteBatch::new();
+				batch.put_with_options(encoded_field_key, value, &put_opts);
+				let new_meta = HashMetaValue::new(seq, 1);
+				batch.put_with_options(meta_encoded_key, new_meta.encode(), &put_opts);
+				batch
+			})
+			.await?;
 			return Ok(1);
 		};
 
 		// Check if field already exists in current generation
-		let existing_field_raw = self
-			.hash_db
-			.get_key_value(encoded_field_key.clone())
-			.await?;
+		let existing_field_raw = self.db.get_key_value(encoded_field_key.clone()).await?;
 
 		let field_exists = existing_field_raw
 			.as_ref()
 			.is_some_and(|kv| kv.seq >= meta_val.version);
 		let is_new_field = !field_exists;
 
-		// Set the field in hash_db
-		self.hash_db
-			.put_with_options(encoded_field_key, value, &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(encoded_field_key, value, &put_opts);
 
-		// Update metadata in string_db if needed
+		// Update metadata if needed.
 		if is_new_field {
 			meta_val.len += 1;
 
 			let put_opts = Storage::meta_put_opts(&meta_val);
 
-			self.string_db
-				.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-				.await?;
+			batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
+			self.write_batch(batch).await?;
 			Ok(1)
 		} else {
+			self.write_batch(batch).await?;
 			Ok(0)
 		}
 	}
@@ -80,7 +74,10 @@ impl Storage {
 		};
 
 		let field_key = HashFieldKey::new(key, field);
-		let result = self.hash_db.get_key_value(field_key.encode()).await?;
+		let result = self
+			.db
+			.get_key_value(Segment::Hash.wrap(field_key.encode()))
+			.await?;
 		if let Some(kv) = result
 			&& kv.seq >= meta_val.version
 		{
@@ -117,23 +114,19 @@ impl Storage {
 		let futures: Vec<_> = fields
 			.iter()
 			.map(|field| {
-				// We don't need to call self.hget() which repeats the check, we can access
-				// hash_db directly
+				// We don't need to call self.hget() which repeats the metadata check.
 				let field_key = HashFieldKey::new(key.clone(), field.clone());
-				// We need to clone the db handle for the closure/future if needed, but
-				// self.hash_db is Arc Actually self.hash_db.get is async.
-				// We can just call self.hash_db.get
 				async move {
 					let k = field_key.encode();
-					self.hash_db
-						.get_key_value(k)
+					self.db
+						.get_key_value(Segment::Hash.wrap(k))
 						.await
 						.map_err(StorageError::from)
 				}
 			})
 			.collect();
 
-		// The error handling types need to match. hash_db.get returns SlateDB error.
+		// The error handling types need to match. SlateDB returns its own error.
 		// hget returns Box<dyn Error>.
 		// try_join_all expects futures to return Result<T, E> where E is same.
 		// slateDB errors satisfy Into<Box<dyn Error>>? Maybe.
@@ -160,10 +153,10 @@ impl Storage {
 		};
 
 		// Construct prefix: len(user_key) + user_key
-		let prefix = user_key_prefix(&key);
+		let prefix = Segment::Hash.wrap(user_key_prefix(&key));
 
 		let range = prefix.clone()..;
-		let mut stream = self.hash_db.scan(range).await?;
+		let mut stream = self.db.scan(range).await?;
 		let mut results = Vec::new();
 
 		while let Some(kv) = stream.next().await? {
@@ -201,7 +194,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn hdel(&self, key: Bytes, fields: &[Bytes]) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 
 		// check meta
 		let mut meta_val = match self.get_meta::<HashMetaValue>(&key).await? {
@@ -210,24 +203,20 @@ impl Storage {
 		};
 
 		let mut deleted_count = 0;
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let mut batch = WriteBatch::new();
 
 		for field in fields {
 			let field_key = HashFieldKey::new(key.clone(), field.clone());
-			let encoded_field_key = field_key.encode();
+			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 
 			// check if field exists
 			let exists = self
-				.hash_db
+				.db
 				.get_key_value(encoded_field_key.clone())
 				.await?
 				.is_some_and(|kv| kv.seq >= meta_val.version);
 			if exists {
-				self.hash_db
-					.delete_with_options(encoded_field_key, &write_opts)
-					.await?;
+				batch.delete(encoded_field_key);
 				deleted_count += 1;
 			}
 		}
@@ -235,19 +224,16 @@ impl Storage {
 		if deleted_count > 0 {
 			if meta_val.len <= deleted_count as u64 {
 				// Hash is empty, delete meta
-				self.string_db
-					.delete_with_options(meta_encoded_key, &write_opts)
-					.await?;
+				batch.delete(meta_encoded_key);
 			} else {
 				// Update meta
 				meta_val.len -= deleted_count as u64;
 
 				let put_opts = Storage::meta_put_opts(&meta_val);
 
-				self.string_db
-					.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-					.await?;
+				batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
 			}
+			self.write_batch(batch).await?;
 		}
 
 		Ok(deleted_count)

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -188,8 +188,12 @@ impl Storage {
 
 		let mut deleted_count = 0;
 		let mut batch = WriteBatch::new();
+		let mut seen_fields = std::collections::HashSet::new();
 
 		for field in fields {
+			if !seen_fields.insert(field.clone()) {
+				continue;
+			}
 			let field_key = HashFieldKey::new(key.clone(), meta_val.version, field.clone());
 			let encoded_field_key = field_key.encode();
 
@@ -397,6 +401,33 @@ mod tests {
 
 		let got = storage.hget(key.clone(), field.clone()).await.unwrap();
 		assert_eq!(got, Some(Bytes::from("v2")));
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_hdel_counts_duplicate_fields_once() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("hash_hdel_duplicates");
+		let f1 = Bytes::from("f1");
+		let f2 = Bytes::from("f2");
+
+		storage
+			.hset(key.clone(), f1.clone(), Bytes::from("v1"))
+			.await
+			.unwrap();
+		storage
+			.hset(key.clone(), f2.clone(), Bytes::from("v2"))
+			.await
+			.unwrap();
+
+		let removed = storage.hdel(key.clone(), &[f1.clone(), f1]).await.unwrap();
+		assert_eq!(removed, 1);
+		assert_eq!(storage.hlen(key.clone()).await.unwrap(), 1);
+		assert_eq!(
+			storage.hget(key.clone(), f2.clone()).await.unwrap(),
+			Some(Bytes::from("v2"))
+		);
 
 		let _ = std::fs::remove_dir_all(path);
 	}

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -7,18 +7,16 @@ use slatedb::config::PutOptions;
 
 use crate::error::StorageError;
 use crate::hash::field_key::HashFieldKey;
-use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::HashMetaValue;
 use crate::string::meta::MetaKey;
-use crate::utils::collection_version_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn hset(&self, key: Bytes, field: Bytes, value: Bytes) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 		let put_opts = PutOptions::default();
 
 		let meta_val = self.get_meta::<HashMetaValue>(&key).await?;
@@ -26,7 +24,7 @@ impl Storage {
 		let Some(mut meta_val) = meta_val else {
 			let version = self.next_version();
 			let field_key = HashFieldKey::new(key.clone(), version, field);
-			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
+			let encoded_field_key = field_key.encode();
 			let mut batch = WriteBatch::new();
 			batch.put_with_options(encoded_field_key, value, &put_opts);
 			let new_meta = HashMetaValue::new(version, 1);
@@ -37,7 +35,7 @@ impl Storage {
 		};
 
 		let field_key = HashFieldKey::new(key.clone(), meta_val.version, field);
-		let encoded_field_key = Segment::Hash.wrap(field_key.encode());
+		let encoded_field_key = field_key.encode();
 
 		// Check if field already exists in current version
 		let existing_field_raw = self.db.get_key_value(encoded_field_key.clone()).await?;
@@ -72,10 +70,7 @@ impl Storage {
 		};
 
 		let field_key = HashFieldKey::new(key, meta_val.version, field);
-		let result = self
-			.db
-			.get_key_value(Segment::Hash.wrap(field_key.encode()))
-			.await?;
+		let result = self.db.get_key_value(field_key.encode()).await?;
 		if let Some(kv) = result {
 			return Ok(Some(kv.value));
 		}
@@ -114,10 +109,7 @@ impl Storage {
 				let field_key = HashFieldKey::new(key.clone(), version, field.clone());
 				async move {
 					let k = field_key.encode();
-					self.db
-						.get_key_value(Segment::Hash.wrap(k))
-						.await
-						.map_err(StorageError::from)
+					self.db.get_key_value(k).await.map_err(StorageError::from)
 				}
 			})
 			.collect();
@@ -149,7 +141,7 @@ impl Storage {
 		};
 
 		// Construct prefix: len(user_key) + user_key + version
-		let prefix = Segment::Hash.wrap(collection_version_prefix(&key, meta_val.version));
+		let prefix = HashFieldKey::prefix(&key, meta_val.version);
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -186,7 +178,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn hdel(&self, key: Bytes, fields: &[Bytes]) -> Result<i64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 
 		// check meta
 		let mut meta_val = match self.get_meta::<HashMetaValue>(&key).await? {
@@ -199,7 +191,7 @@ impl Storage {
 
 		for field in fields {
 			let field_key = HashFieldKey::new(key.clone(), meta_val.version, field.clone());
-			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
+			let encoded_field_key = field_key.encode();
 
 			// check if field exists
 			let exists = self

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -11,7 +11,7 @@ use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::HashMetaValue;
 use crate::string::meta::MetaKey;
-use crate::utils::collection_generation_prefix;
+use crate::utils::collection_version_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
@@ -24,12 +24,12 @@ impl Storage {
 		let meta_val = self.get_meta::<HashMetaValue>(&key).await?;
 
 		let Some(mut meta_val) = meta_val else {
-			let generation = self.next_generation();
-			let field_key = HashFieldKey::new(key.clone(), generation, field);
+			let version = self.next_version();
+			let field_key = HashFieldKey::new(key.clone(), version, field);
 			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 			let mut batch = WriteBatch::new();
 			batch.put_with_options(encoded_field_key, value, &put_opts);
-			let new_meta = HashMetaValue::new(generation, 1);
+			let new_meta = HashMetaValue::new(version, 1);
 			let meta_put_opts = Storage::meta_put_opts(&new_meta);
 			batch.put_with_options(meta_encoded_key, new_meta.encode(), &meta_put_opts);
 			self.write_batch(batch).await?;
@@ -39,7 +39,7 @@ impl Storage {
 		let field_key = HashFieldKey::new(key.clone(), meta_val.version, field);
 		let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 
-		// Check if field already exists in current generation
+		// Check if field already exists in current version
 		let existing_field_raw = self.db.get_key_value(encoded_field_key.clone()).await?;
 
 		let field_exists = existing_field_raw.as_ref().is_some();
@@ -148,8 +148,8 @@ impl Storage {
 			return Ok(Vec::new());
 		};
 
-		// Construct prefix: len(user_key) + user_key + generation
-		let prefix = Segment::Hash.wrap(collection_generation_prefix(&key, meta_val.version));
+		// Construct prefix: len(user_key) + user_key + version
+		let prefix = Segment::Hash.wrap(collection_version_prefix(&key, meta_val.version));
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -162,7 +162,7 @@ impl Storage {
 				break;
 			}
 
-			// Parse field: prefix (key_len+key+generation) + field_len(u32) + field
+			// Parse field: prefix (key_len+key+version) + field_len(u32) + field
 			let suffix = &k[prefix.len()..];
 			if suffix.len() < 4 {
 				continue;

--- a/nimbis-storage/src/storage_hash.rs
+++ b/nimbis-storage/src/storage_hash.rs
@@ -11,7 +11,7 @@ use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::HashMetaValue;
 use crate::string::meta::MetaKey;
-use crate::utils::user_key_prefix;
+use crate::utils::collection_generation_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
@@ -21,30 +21,28 @@ impl Storage {
 		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
-		// Now create field key with the version from metadata
-		let field_key = HashFieldKey::new(key.clone(), field);
-		let encoded_field_key = Segment::Hash.wrap(field_key.encode());
-
 		let meta_val = self.get_meta::<HashMetaValue>(&key).await?;
 
 		let Some(mut meta_val) = meta_val else {
-			self.write_batch_with_seq(|seq| {
-				let mut batch = WriteBatch::new();
-				batch.put_with_options(encoded_field_key, value, &put_opts);
-				let new_meta = HashMetaValue::new(seq, 1);
-				batch.put_with_options(meta_encoded_key, new_meta.encode(), &put_opts);
-				batch
-			})
-			.await?;
+			let generation = self.next_generation();
+			let field_key = HashFieldKey::new(key.clone(), generation, field);
+			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
+			let mut batch = WriteBatch::new();
+			batch.put_with_options(encoded_field_key, value, &put_opts);
+			let new_meta = HashMetaValue::new(generation, 1);
+			let meta_put_opts = Storage::meta_put_opts(&new_meta);
+			batch.put_with_options(meta_encoded_key, new_meta.encode(), &meta_put_opts);
+			self.write_batch(batch).await?;
 			return Ok(1);
 		};
+
+		let field_key = HashFieldKey::new(key.clone(), meta_val.version, field);
+		let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 
 		// Check if field already exists in current generation
 		let existing_field_raw = self.db.get_key_value(encoded_field_key.clone()).await?;
 
-		let field_exists = existing_field_raw
-			.as_ref()
-			.is_some_and(|kv| kv.seq >= meta_val.version);
+		let field_exists = existing_field_raw.as_ref().is_some();
 		let is_new_field = !field_exists;
 
 		let mut batch = WriteBatch::new();
@@ -73,14 +71,12 @@ impl Storage {
 			return Ok(None);
 		};
 
-		let field_key = HashFieldKey::new(key, field);
+		let field_key = HashFieldKey::new(key, meta_val.version, field);
 		let result = self
 			.db
 			.get_key_value(Segment::Hash.wrap(field_key.encode()))
 			.await?;
-		if let Some(kv) = result
-			&& kv.seq >= meta_val.version
-		{
+		if let Some(kv) = result {
 			return Ok(Some(kv.value));
 		}
 		Ok(None)
@@ -115,7 +111,7 @@ impl Storage {
 			.iter()
 			.map(|field| {
 				// We don't need to call self.hget() which repeats the metadata check.
-				let field_key = HashFieldKey::new(key.clone(), field.clone());
+				let field_key = HashFieldKey::new(key.clone(), version, field.clone());
 				async move {
 					let k = field_key.encode();
 					self.db
@@ -138,7 +134,7 @@ impl Storage {
 		Ok(results
 			.into_iter()
 			.map(|kv| match kv {
-				Some(kv) if kv.seq >= version => Some(kv.value),
+				Some(kv) => Some(kv.value),
 				_ => None,
 			})
 			.collect())
@@ -152,8 +148,8 @@ impl Storage {
 			return Ok(Vec::new());
 		};
 
-		// Construct prefix: len(user_key) + user_key
-		let prefix = Segment::Hash.wrap(user_key_prefix(&key));
+		// Construct prefix: len(user_key) + user_key + generation
+		let prefix = Segment::Hash.wrap(collection_generation_prefix(&key, meta_val.version));
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -166,11 +162,7 @@ impl Storage {
 				break;
 			}
 
-			if kv.seq < meta_val.version {
-				continue;
-			}
-
-			// Parse field: prefix (key_len+key) + field_len(u32) + field
+			// Parse field: prefix (key_len+key+generation) + field_len(u32) + field
 			let suffix = &k[prefix.len()..];
 			if suffix.len() < 4 {
 				continue;
@@ -206,7 +198,7 @@ impl Storage {
 		let mut batch = WriteBatch::new();
 
 		for field in fields {
-			let field_key = HashFieldKey::new(key.clone(), field.clone());
+			let field_key = HashFieldKey::new(key.clone(), meta_val.version, field.clone());
 			let encoded_field_key = Segment::Hash.wrap(field_key.encode());
 
 			// check if field exists
@@ -214,7 +206,7 @@ impl Storage {
 				.db
 				.get_key_value(encoded_field_key.clone())
 				.await?
-				.is_some_and(|kv| kv.seq >= meta_val.version);
+				.is_some();
 			if exists {
 				batch.delete(encoded_field_key);
 				deleted_count += 1;

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -45,7 +45,7 @@ impl Storage {
 
 		let mut meta_val = match self.get_meta::<ListMetaValue>(&key).await? {
 			Some(m) => m,
-			None => ListMetaValue::new(self.next_generation()),
+			None => ListMetaValue::new(self.next_version()),
 		};
 		let mut batch = WriteBatch::new();
 

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -7,7 +7,6 @@ use slatedb::config::PutOptions;
 
 use crate::error::StorageError;
 use crate::list::element_key::ListElementKey;
-use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::ListMetaValue;
 use crate::string::meta::MetaKey;
@@ -40,7 +39,7 @@ impl Storage {
 		}
 
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 		let put_opts = PutOptions::default();
 
 		let mut meta_val = match self.get_meta::<ListMetaValue>(&key).await? {
@@ -60,7 +59,7 @@ impl Storage {
 			};
 
 			let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
-			batch.put_with_options(Segment::List.wrap(element_key.encode()), element, &put_opts);
+			batch.put_with_options(element_key.encode(), element, &put_opts);
 			meta_val.len += 1;
 		}
 
@@ -112,7 +111,7 @@ impl Storage {
 			};
 
 			let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
-			let encoded_key = Segment::List.wrap(element_key.encode());
+			let encoded_key = element_key.encode();
 			// Get element
 			if let Some(val) = self
 				.db
@@ -136,7 +135,7 @@ impl Storage {
 
 		// Update metadata
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 
 		if meta_val.len == 0 {
 			// List empty, delete metadata
@@ -216,7 +215,7 @@ impl Storage {
 				let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
 				async move {
 					self.db
-						.get_key_value(Segment::List.wrap(element_key.encode()))
+						.get_key_value(element_key.encode())
 						.await
 						.map_err(StorageError::from)
 				}

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -43,9 +43,9 @@ impl Storage {
 		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
-		let (mut meta_val, meta_missing) = match self.get_meta::<ListMetaValue>(&key).await? {
-			Some(m) => (m, false),
-			None => (ListMetaValue::new(0), true),
+		let mut meta_val = match self.get_meta::<ListMetaValue>(&key).await? {
+			Some(m) => m,
+			None => ListMetaValue::new(self.next_generation()),
 		};
 		let mut batch = WriteBatch::new();
 
@@ -59,23 +59,15 @@ impl Storage {
 				s
 			};
 
-			let element_key = ListElementKey::new(key.clone(), seq);
+			let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
 			batch.put_with_options(Segment::List.wrap(element_key.encode()), element, &put_opts);
 			meta_val.len += 1;
 		}
 
-		self.write_batch_with_seq(|seq| {
-			if meta_missing {
-				meta_val.version = seq;
-			}
-
-			// Update metadata
-			let meta_put_opts = Storage::meta_put_opts(&meta_val);
-
-			batch.put_with_options(meta_encoded_key, meta_val.encode(), &meta_put_opts);
-			batch
-		})
-		.await?;
+		// Update metadata
+		let meta_put_opts = Storage::meta_put_opts(&meta_val);
+		batch.put_with_options(meta_encoded_key, meta_val.encode(), &meta_put_opts);
+		self.write_batch(batch).await?;
 
 		Ok(meta_val.len)
 	}
@@ -119,14 +111,13 @@ impl Storage {
 				meta_val.tail - 1
 			};
 
-			let element_key = ListElementKey::new(key.clone(), seq);
+			let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
 			let encoded_key = Segment::List.wrap(element_key.encode());
 			// Get element
 			if let Some(val) = self
 				.db
 				.get_key_value(encoded_key.clone())
 				.await?
-				.filter(|kv| kv.seq >= meta_val.version)
 				.map(|kv| kv.value)
 			{
 				results.push(val);
@@ -222,7 +213,7 @@ impl Storage {
 
 		let futures: Vec<_> = (start_seq..=stop_seq)
 			.map(|seq| {
-				let element_key = ListElementKey::new(key.clone(), seq);
+				let element_key = ListElementKey::new(key.clone(), meta_val.version, seq);
 				async move {
 					self.db
 						.get_key_value(Segment::List.wrap(element_key.encode()))
@@ -235,9 +226,7 @@ impl Storage {
 		let found_results = future::try_join_all(futures).await?;
 
 		for res in found_results {
-			if let Some(kv) = res
-				&& kv.seq >= meta_val.version
-			{
+			if let Some(kv) = res {
 				results.push(kv.value);
 			} else {
 				// Should not happen if consistency is maintained

--- a/nimbis-storage/src/storage_list.rs
+++ b/nimbis-storage/src/storage_list.rs
@@ -2,11 +2,12 @@ use bytes::Bytes;
 use futures::future;
 use log::warn;
 use nimbis_macros::storage_lock;
+use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
-use slatedb::config::WriteOptions;
 
 use crate::error::StorageError;
 use crate::list::element_key::ListElementKey;
+use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::ListMetaValue;
 use crate::string::meta::MetaKey;
@@ -39,17 +40,14 @@ impl Storage {
 		}
 
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
 		let (mut meta_val, meta_missing) = match self.get_meta::<ListMetaValue>(&key).await? {
 			Some(m) => (m, false),
 			None => (ListMetaValue::new(0), true),
 		};
-		let mut first_insert_seq: Option<u64> = None;
+		let mut batch = WriteBatch::new();
 
 		for element in elements {
 			let seq = if is_left {
@@ -62,33 +60,22 @@ impl Storage {
 			};
 
 			let element_key = ListElementKey::new(key.clone(), seq);
-			let wh = self
-				.list_db
-				.put_with_options(element_key.encode(), element, &put_opts, &write_opts)
-				.await?;
-			if meta_missing && first_insert_seq.is_none() {
-				first_insert_seq = Some(wh.seqnum());
-			}
+			batch.put_with_options(Segment::List.wrap(element_key.encode()), element, &put_opts);
 			meta_val.len += 1;
 		}
 
-		if meta_missing {
-			meta_val.version = first_insert_seq.ok_or_else(|| StorageError::DataInconsistency {
-				message: "missing first new list element seq after write".to_string(),
-			})?;
-		}
+		self.write_batch_with_seq(|seq| {
+			if meta_missing {
+				meta_val.version = seq;
+			}
 
-		// Update metadata
-		let meta_put_opts = Storage::meta_put_opts(&meta_val);
+			// Update metadata
+			let meta_put_opts = Storage::meta_put_opts(&meta_val);
 
-		self.string_db
-			.put_with_options(
-				meta_encoded_key,
-				meta_val.encode(),
-				&meta_put_opts,
-				&write_opts,
-			)
-			.await?;
+			batch.put_with_options(meta_encoded_key, meta_val.encode(), &meta_put_opts);
+			batch
+		})
+		.await?;
 
 		Ok(meta_val.len)
 	}
@@ -120,9 +107,7 @@ impl Storage {
 		}
 
 		let mut results = Vec::with_capacity(num);
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let mut batch = WriteBatch::new();
 
 		// We will pop up to `num` elements
 		let loop_count = std::cmp::min(num as u64, meta_val.len);
@@ -135,10 +120,11 @@ impl Storage {
 			};
 
 			let element_key = ListElementKey::new(key.clone(), seq);
+			let encoded_key = Segment::List.wrap(element_key.encode());
 			// Get element
 			if let Some(val) = self
-				.list_db
-				.get_key_value(element_key.encode())
+				.db
+				.get_key_value(encoded_key.clone())
 				.await?
 				.filter(|kv| kv.seq >= meta_val.version)
 				.map(|kv| kv.value)
@@ -153,31 +139,25 @@ impl Storage {
 				}
 				meta_val.len -= 1;
 
-				self.list_db
-					.delete_with_options(element_key.encode(), &write_opts)
-					.await?;
+				batch.delete(encoded_key);
 			}
 		}
 
 		// Update metadata
 		let meta_key = MetaKey::new(key.clone());
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 
 		if meta_val.len == 0 {
 			// List empty, delete metadata
-			self.string_db
-				.delete_with_options(meta_key.encode(), &write_opts)
-				.await?;
+			batch.delete(meta_encoded_key);
 		} else {
 			let meta_put_opts = Storage::meta_put_opts(&meta_val);
 
-			self.string_db
-				.put_with_options(
-					meta_key.encode(),
-					meta_val.encode(),
-					&meta_put_opts,
-					&write_opts,
-				)
-				.await?;
+			batch.put_with_options(meta_encoded_key, meta_val.encode(), &meta_put_opts);
+		}
+
+		if !results.is_empty() {
+			self.write_batch(batch).await?;
 		}
 
 		Ok(results)
@@ -244,8 +224,8 @@ impl Storage {
 			.map(|seq| {
 				let element_key = ListElementKey::new(key.clone(), seq);
 				async move {
-					self.list_db
-						.get_key_value(element_key.encode())
+					self.db
+						.get_key_value(Segment::List.wrap(element_key.encode()))
 						.await
 						.map_err(StorageError::from)
 				}

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -1,10 +1,11 @@
 use bytes::Buf;
 use bytes::Bytes;
 use nimbis_macros::storage_lock;
+use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
-use slatedb::config::WriteOptions;
 
 use crate::error::StorageError;
+use crate::segment::Segment;
 use crate::set::member_key::SetMemberKey;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
@@ -16,10 +17,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn sadd(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
 		let (mut meta_val, meta_missing) = match self.get_meta::<SetMetaValue>(&key).await? {
@@ -35,51 +33,43 @@ impl Storage {
 			.collect();
 
 		let mut added_count = 0;
-		let mut first_added_seq: Option<u64> = None;
+		let mut batch = WriteBatch::new();
 
 		for member in members {
 			let member_key = SetMemberKey::new(key.clone(), member);
-			let encoded_member_key = member_key.encode();
+			let encoded_member_key = Segment::Set.wrap(member_key.encode());
 			let exists = if meta_missing {
 				false
 			} else {
-				self.set_db
+				self.db
 					.get_key_value(encoded_member_key.clone())
 					.await?
 					.is_some_and(|kv| kv.seq >= meta_val.version)
 			};
 
 			if !exists {
-				let wh = self
-					.set_db
-					.put_with_options(
-						encoded_member_key,
-						Bytes::new(), // value is empty for set members
-						&put_opts,
-						&write_opts,
-					)
-					.await?;
-				if meta_missing && first_added_seq.is_none() {
-					first_added_seq = Some(wh.seqnum());
-				}
+				batch.put_with_options(
+					encoded_member_key,
+					Bytes::new(), // value is empty for set members
+					&put_opts,
+				);
 				added_count += 1;
 			}
 		}
 
 		if added_count > 0 {
-			if meta_missing {
-				meta_val.version =
-					first_added_seq.ok_or_else(|| StorageError::DataInconsistency {
-						message: "missing first new set member seq after write".to_string(),
-					})?;
-			}
-			meta_val.len += added_count;
+			self.write_batch_with_seq(|seq| {
+				if meta_missing {
+					meta_val.version = seq;
+				}
+				meta_val.len += added_count;
 
-			let put_opts = Storage::meta_put_opts(&meta_val);
+				let put_opts = Storage::meta_put_opts(&meta_val);
 
-			self.string_db
-				.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-				.await?;
+				batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
+				batch
+			})
+			.await?;
 		}
 
 		Ok(added_count)
@@ -93,10 +83,10 @@ impl Storage {
 		};
 
 		// Construct prefix: len(user_key) + user_key
-		let prefix = user_key_prefix(&key);
+		let prefix = Segment::Set.wrap(user_key_prefix(&key));
 
 		let range = prefix.clone()..;
-		let mut stream = self.set_db.scan(range).await?;
+		let mut stream = self.db.scan(range).await?;
 		let mut members = Vec::new();
 
 		while let Some(kv) = stream.next().await? {
@@ -137,8 +127,8 @@ impl Storage {
 
 		let member_key = SetMemberKey::new(key, member);
 		let found = self
-			.set_db
-			.get_key_value(member_key.encode())
+			.db
+			.get_key_value(Segment::Set.wrap(member_key.encode()))
 			.await?
 			.is_some_and(|kv| kv.seq >= meta_val.version);
 		Ok(found)
@@ -148,7 +138,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn srem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 
 		let mut meta_val = match self.get_meta::<SetMetaValue>(&key).await? {
 			Some(val) => val,
@@ -156,23 +146,19 @@ impl Storage {
 		};
 
 		let mut removed_count = 0;
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let mut batch = WriteBatch::new();
 
 		for member in members {
 			let member_key = SetMemberKey::new(key.clone(), member);
-			let encoded_key = member_key.encode();
+			let encoded_key = Segment::Set.wrap(member_key.encode());
 			let exists = self
-				.set_db
+				.db
 				.get_key_value(encoded_key.clone())
 				.await?
 				.is_some_and(|kv| kv.seq >= meta_val.version);
 
 			if exists {
-				self.set_db
-					.delete_with_options(encoded_key, &write_opts)
-					.await?;
+				batch.delete(encoded_key);
 				removed_count += 1;
 			}
 		}
@@ -180,15 +166,12 @@ impl Storage {
 		if removed_count > 0 {
 			meta_val.len -= removed_count;
 			if meta_val.len == 0 {
-				self.string_db
-					.delete_with_options(meta_encoded_key, &write_opts)
-					.await?;
+				batch.delete(meta_encoded_key);
 			} else {
 				let put_opts = Storage::meta_put_opts(&meta_val);
-				self.string_db
-					.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-					.await?;
+				batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
 			}
+			self.write_batch(batch).await?;
 		}
 
 		Ok(removed_count)

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -10,7 +10,7 @@ use crate::set::member_key::SetMemberKey;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
 use crate::string::meta::SetMetaValue;
-use crate::utils::collection_generation_prefix;
+use crate::utils::collection_version_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
@@ -22,7 +22,7 @@ impl Storage {
 
 		let (mut meta_val, meta_missing) = match self.get_meta::<SetMetaValue>(&key).await? {
 			Some(meta) => (meta, false),
-			None => (SetMetaValue::new(self.next_generation(), 0), true),
+			None => (SetMetaValue::new(self.next_version(), 0), true),
 		};
 
 		// Deduplicate members, keeping the first occurrence
@@ -76,8 +76,8 @@ impl Storage {
 			return Ok(Vec::new());
 		};
 
-		// Construct prefix: len(user_key) + user_key + generation
-		let prefix = Segment::Set.wrap(collection_generation_prefix(&key, meta_val.version));
+		// Construct prefix: len(user_key) + user_key + version
+		let prefix = Segment::Set.wrap(collection_version_prefix(&key, meta_val.version));
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -88,7 +88,7 @@ impl Storage {
 			if !k.starts_with(&prefix) {
 				break;
 			}
-			// Parse member: prefix (key_len+key+generation) + member_len(u32) + member
+			// Parse member: prefix (key_len+key+version) + member_len(u32) + member
 			let suffix = &k[prefix.len()..];
 			if suffix.len() < 4 {
 				continue;

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -10,7 +10,7 @@ use crate::set::member_key::SetMemberKey;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
 use crate::string::meta::SetMetaValue;
-use crate::utils::user_key_prefix;
+use crate::utils::collection_generation_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
@@ -22,7 +22,7 @@ impl Storage {
 
 		let (mut meta_val, meta_missing) = match self.get_meta::<SetMetaValue>(&key).await? {
 			Some(meta) => (meta, false),
-			None => (SetMetaValue::new(0, 0), true),
+			None => (SetMetaValue::new(self.next_generation(), 0), true),
 		};
 
 		// Deduplicate members, keeping the first occurrence
@@ -36,7 +36,7 @@ impl Storage {
 		let mut batch = WriteBatch::new();
 
 		for member in members {
-			let member_key = SetMemberKey::new(key.clone(), member);
+			let member_key = SetMemberKey::new(key.clone(), meta_val.version, member);
 			let encoded_member_key = Segment::Set.wrap(member_key.encode());
 			let exists = if meta_missing {
 				false
@@ -44,7 +44,7 @@ impl Storage {
 				self.db
 					.get_key_value(encoded_member_key.clone())
 					.await?
-					.is_some_and(|kv| kv.seq >= meta_val.version)
+					.is_some()
 			};
 
 			if !exists {
@@ -58,18 +58,12 @@ impl Storage {
 		}
 
 		if added_count > 0 {
-			self.write_batch_with_seq(|seq| {
-				if meta_missing {
-					meta_val.version = seq;
-				}
-				meta_val.len += added_count;
+			meta_val.len += added_count;
 
-				let put_opts = Storage::meta_put_opts(&meta_val);
+			let put_opts = Storage::meta_put_opts(&meta_val);
 
-				batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
-				batch
-			})
-			.await?;
+			batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
+			self.write_batch(batch).await?;
 		}
 
 		Ok(added_count)
@@ -82,8 +76,8 @@ impl Storage {
 			return Ok(Vec::new());
 		};
 
-		// Construct prefix: len(user_key) + user_key
-		let prefix = Segment::Set.wrap(user_key_prefix(&key));
+		// Construct prefix: len(user_key) + user_key + generation
+		let prefix = Segment::Set.wrap(collection_generation_prefix(&key, meta_val.version));
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -94,11 +88,7 @@ impl Storage {
 			if !k.starts_with(&prefix) {
 				break;
 			}
-			if kv.seq < meta_val.version {
-				continue;
-			}
-
-			// Parse member: prefix (key_len+key) + member_len(u32) + member
+			// Parse member: prefix (key_len+key+generation) + member_len(u32) + member
 			let suffix = &k[prefix.len()..];
 			if suffix.len() < 4 {
 				continue;
@@ -125,12 +115,12 @@ impl Storage {
 			return Ok(false);
 		};
 
-		let member_key = SetMemberKey::new(key, member);
+		let member_key = SetMemberKey::new(key, meta_val.version, member);
 		let found = self
 			.db
 			.get_key_value(Segment::Set.wrap(member_key.encode()))
 			.await?
-			.is_some_and(|kv| kv.seq >= meta_val.version);
+			.is_some();
 		Ok(found)
 	}
 
@@ -149,13 +139,9 @@ impl Storage {
 		let mut batch = WriteBatch::new();
 
 		for member in members {
-			let member_key = SetMemberKey::new(key.clone(), member);
+			let member_key = SetMemberKey::new(key.clone(), meta_val.version, member);
 			let encoded_key = Segment::Set.wrap(member_key.encode());
-			let exists = self
-				.db
-				.get_key_value(encoded_key.clone())
-				.await?
-				.is_some_and(|kv| kv.seq >= meta_val.version);
+			let exists = self.db.get_key_value(encoded_key.clone()).await?.is_some();
 
 			if exists {
 				batch.delete(encoded_key);

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -5,19 +5,17 @@ use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
 
 use crate::error::StorageError;
-use crate::segment::Segment;
 use crate::set::member_key::SetMemberKey;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
 use crate::string::meta::SetMetaValue;
-use crate::utils::collection_version_prefix;
 
 impl Storage {
 	#[storage_lock(write, key)]
 	#[fastrace::trace]
 	pub async fn sadd(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 		let put_opts = PutOptions::default();
 
 		let (mut meta_val, meta_missing) = match self.get_meta::<SetMetaValue>(&key).await? {
@@ -37,7 +35,7 @@ impl Storage {
 
 		for member in members {
 			let member_key = SetMemberKey::new(key.clone(), meta_val.version, member);
-			let encoded_member_key = Segment::Set.wrap(member_key.encode());
+			let encoded_member_key = member_key.encode();
 			let exists = if meta_missing {
 				false
 			} else {
@@ -77,7 +75,7 @@ impl Storage {
 		};
 
 		// Construct prefix: len(user_key) + user_key + version
-		let prefix = Segment::Set.wrap(collection_version_prefix(&key, meta_val.version));
+		let prefix = SetMemberKey::prefix(&key, meta_val.version);
 
 		let range = prefix.clone()..;
 		let mut stream = self.db.scan(range).await?;
@@ -116,11 +114,7 @@ impl Storage {
 		};
 
 		let member_key = SetMemberKey::new(key, meta_val.version, member);
-		let found = self
-			.db
-			.get_key_value(Segment::Set.wrap(member_key.encode()))
-			.await?
-			.is_some();
+		let found = self.db.get_key_value(member_key.encode()).await?.is_some();
 		Ok(found)
 	}
 
@@ -128,7 +122,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn srem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 
 		let mut meta_val = match self.get_meta::<SetMetaValue>(&key).await? {
 			Some(val) => val,
@@ -140,7 +134,7 @@ impl Storage {
 
 		for member in members {
 			let member_key = SetMemberKey::new(key.clone(), meta_val.version, member);
-			let encoded_key = Segment::Set.wrap(member_key.encode());
+			let encoded_key = member_key.encode();
 			let exists = self.db.get_key_value(encoded_key.clone()).await?.is_some();
 
 			if exists {

--- a/nimbis-storage/src/storage_set.rs
+++ b/nimbis-storage/src/storage_set.rs
@@ -129,10 +129,14 @@ impl Storage {
 			None => return Ok(0),
 		};
 
+		let mut seen_members = std::collections::HashSet::new();
 		let mut removed_count = 0;
 		let mut batch = WriteBatch::new();
 
 		for member in members {
+			if !seen_members.insert(member.clone()) {
+				continue;
+			}
 			let member_key = SetMemberKey::new(key.clone(), meta_val.version, member);
 			let encoded_key = member_key.encode();
 			let exists = self.db.get_key_value(encoded_key.clone()).await?.is_some();
@@ -256,6 +260,29 @@ mod tests {
 
 		storage.sadd(key.clone(), vec![m1.clone()]).await.unwrap();
 		assert_eq!(storage.scard(key.clone()).await.unwrap(), 1);
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_srem_counts_duplicate_members_once() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("set_srem_duplicates");
+		let m1 = Bytes::from("m1");
+		let m2 = Bytes::from("m2");
+
+		storage
+			.sadd(key.clone(), vec![m1.clone(), m2.clone()])
+			.await
+			.unwrap();
+
+		let removed = storage
+			.srem(key.clone(), vec![m1.clone(), m1])
+			.await
+			.unwrap();
+		assert_eq!(removed, 1);
+		assert_eq!(storage.scard(key.clone()).await.unwrap(), 1);
+		assert!(storage.sismember(key.clone(), m2).await.unwrap());
 
 		let _ = std::fs::remove_dir_all(path);
 	}

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -7,7 +7,6 @@ use slatedb::config::Ttl;
 
 use crate::data_type::DataType;
 use crate::error::StorageError;
-use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::key::StringKey;
 use crate::string::meta::AnyValue;
@@ -33,7 +32,7 @@ impl Storage {
 
 		let put_opts = PutOptions::default();
 		let mut batch = WriteBatch::new();
-		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		batch.put_with_options(key.encode(), value.encode(), &put_opts);
 		self.write_batch(batch).await?;
 		Ok(())
 	}
@@ -57,7 +56,7 @@ impl Storage {
 				continue;
 			}
 
-			batch.delete(Segment::Meta.wrap(key.encode()));
+			batch.delete(key.encode());
 			deleted += 1;
 		}
 
@@ -73,7 +72,7 @@ impl Storage {
 	pub async fn expire(&self, key: Bytes, expire_time: u64) -> Result<bool, StorageError> {
 		let user_key = key.clone();
 		let skey = StringKey::new(key);
-		let encoded_key = Segment::Meta.wrap(skey.encode());
+		let encoded_key = skey.encode();
 
 		// EXPIRE applies to all data types; only existence matters.
 		if self.get_meta::<AnyValue>(&user_key).await?.is_none() {
@@ -109,7 +108,7 @@ impl Storage {
 	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn ttl(&self, key: Bytes) -> Result<Option<i64>, StorageError> {
-		let encoded_key = Segment::Meta.wrap(StringKey::new(key).encode());
+		let encoded_key = StringKey::new(key).encode();
 		let kv = match self.db.get_key_value(encoded_key.clone()).await? {
 			Some(kv) => kv,
 			None => return Ok(None),
@@ -185,7 +184,7 @@ impl Storage {
 
 		let put_opts = PutOptions::default();
 		let mut batch = WriteBatch::new();
-		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		batch.put_with_options(key.encode(), value.encode(), &put_opts);
 		self.write_batch(batch).await?;
 
 		Ok(int_val)
@@ -223,7 +222,7 @@ impl Storage {
 
 		let put_opts = PutOptions::default();
 		let mut batch = WriteBatch::new();
-		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		batch.put_with_options(key.encode(), value.encode(), &put_opts);
 		self.write_batch(batch).await?;
 
 		Ok(int_val)
@@ -254,7 +253,7 @@ impl Storage {
 
 		let put_opts = PutOptions::default();
 		let mut batch = WriteBatch::new();
-		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		batch.put_with_options(key.encode(), value.encode(), &put_opts);
 		self.write_batch(batch).await?;
 
 		Ok(len)

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -10,6 +10,7 @@ use crate::error::StorageError;
 use crate::storage::Storage;
 use crate::string::key::StringKey;
 use crate::string::meta::AnyValue;
+use crate::string::meta::MetaKey;
 use crate::string::value::StringValue;
 use crate::utils::is_expired;
 
@@ -45,10 +46,14 @@ impl Storage {
 	{
 		let mut deleted = 0;
 		let mut batch = WriteBatch::new();
+		let mut seen = std::collections::HashSet::new();
 
 		for key in keys {
 			let user_key = key;
-			let key = StringKey::new(user_key.clone());
+			if !seen.insert(user_key.clone()) {
+				continue;
+			}
+			let key = MetaKey::new(user_key.clone());
 
 			// We need to check existence to return correct number of deleted keys (0 or 1).
 			// Even if we don't use the meta value, we need to know if it exists.
@@ -71,7 +76,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn expire(&self, key: Bytes, expire_time: u64) -> Result<bool, StorageError> {
 		let user_key = key.clone();
-		let skey = StringKey::new(key);
+		let skey = MetaKey::new(key);
 		let encoded_key = skey.encode();
 
 		// EXPIRE applies to all data types; only existence matters.
@@ -108,7 +113,7 @@ impl Storage {
 	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn ttl(&self, key: Bytes) -> Result<Option<i64>, StorageError> {
-		let encoded_key = StringKey::new(key).encode();
+		let encoded_key = MetaKey::new(key).encode();
 		let kv = match self.db.get_key_value(encoded_key.clone()).await? {
 			Some(kv) => kv,
 			None => return Ok(None),
@@ -371,6 +376,43 @@ mod tests {
 		// Since meta is now String, HGET returns WRONGTYPE. Correct.
 		let err = storage.hget(k.clone(), f.clone()).await.unwrap_err();
 		assert!(err.to_string().contains("WRONGTYPE"));
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_del_counts_duplicate_keys_once() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("duplicate_del_key");
+
+		storage
+			.set(key.clone(), Bytes::from("value"))
+			.await
+			.unwrap();
+
+		let deleted = storage.del([key.clone(), key.clone()]).await.unwrap();
+		assert_eq!(deleted, 1);
+		assert!(!storage.exists(key.clone()).await.unwrap());
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_expire_and_ttl_apply_to_collection_metadata() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("hash_with_ttl");
+
+		storage
+			.hset(key.clone(), Bytes::from("field"), Bytes::from("value"))
+			.await
+			.unwrap();
+
+		let expire_at = chrono::Utc::now().timestamp_millis().max(0) as u64 + 10_000;
+		assert!(storage.expire(key.clone(), expire_at).await.unwrap());
+
+		let ttl = storage.ttl(key.clone()).await.unwrap().unwrap();
+		assert!(ttl > 0);
+		assert!(ttl <= 10_000);
 
 		let _ = std::fs::remove_dir_all(path);
 	}

--- a/nimbis-storage/src/storage_string.rs
+++ b/nimbis-storage/src/storage_string.rs
@@ -1,12 +1,13 @@
 use bytes::Bytes;
 use chrono::Utc;
 use nimbis_macros::storage_lock;
+use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
 use slatedb::config::Ttl;
-use slatedb::config::WriteOptions;
 
 use crate::data_type::DataType;
 use crate::error::StorageError;
+use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::key::StringKey;
 use crate::string::meta::AnyValue;
@@ -30,13 +31,10 @@ impl Storage {
 		let key = StringKey::new(key);
 		let value = StringValue::new(value);
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
 		let put_opts = PutOptions::default();
-		self.string_db
-			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		self.write_batch(batch).await?;
 		Ok(())
 	}
 
@@ -47,24 +45,24 @@ impl Storage {
 		I: IntoIterator<Item = Bytes>,
 	{
 		let mut deleted = 0;
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let mut batch = WriteBatch::new();
 
 		for key in keys {
-			let key = StringKey::new(key);
+			let user_key = key;
+			let key = StringKey::new(user_key.clone());
 
 			// We need to check existence to return correct number of deleted keys (0 or 1).
 			// Even if we don't use the meta value, we need to know if it exists.
-			if self.string_db.get(key.encode()).await?.is_none() {
+			if self.get_meta::<AnyValue>(&user_key).await?.is_none() {
 				continue;
 			}
 
-			self.string_db
-				.delete_with_options(key.encode(), &write_opts)
-				.await?;
-
+			batch.delete(Segment::Meta.wrap(key.encode()));
 			deleted += 1;
+		}
+
+		if deleted > 0 {
+			self.write_batch(batch).await?;
 		}
 
 		Ok(deleted)
@@ -75,26 +73,23 @@ impl Storage {
 	pub async fn expire(&self, key: Bytes, expire_time: u64) -> Result<bool, StorageError> {
 		let user_key = key.clone();
 		let skey = StringKey::new(key);
-		let encoded_key = skey.encode();
+		let encoded_key = Segment::Meta.wrap(skey.encode());
 
 		// EXPIRE applies to all data types; only existence matters.
 		if self.get_meta::<AnyValue>(&user_key).await?.is_none() {
 			return Ok(false);
 		}
 
-		let encoded_val = match self.string_db.get(encoded_key.clone()).await? {
+		let encoded_val = match self.db.get(encoded_key.clone()).await? {
 			Some(v) => v,
 			None => return Ok(false),
 		};
 
 		let now = chrono::Utc::now().timestamp_millis().max(0) as u64;
 		if expire_time > 0 && expire_time <= now {
-			let write_opts = WriteOptions {
-				await_durable: false,
-			};
-			self.string_db
-				.delete_with_options(encoded_key, &write_opts)
-				.await?;
+			let mut batch = WriteBatch::new();
+			batch.delete(encoded_key);
+			self.write_batch(batch).await?;
 			return Ok(true);
 		}
 
@@ -104,34 +99,26 @@ impl Storage {
 			Ttl::NoExpiry
 		};
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
-
 		let put_opts = PutOptions { ttl };
-
-		self.string_db
-			.put_with_options(encoded_key, encoded_val, &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(encoded_key, encoded_val, &put_opts);
+		self.write_batch(batch).await?;
 		Ok(true)
 	}
 
 	#[storage_lock(read, key)]
 	#[fastrace::trace]
 	pub async fn ttl(&self, key: Bytes) -> Result<Option<i64>, StorageError> {
-		let encoded_key = StringKey::new(key).encode();
-		let kv = match self.string_db.get_key_value(encoded_key.clone()).await? {
+		let encoded_key = Segment::Meta.wrap(StringKey::new(key).encode());
+		let kv = match self.db.get_key_value(encoded_key.clone()).await? {
 			Some(kv) => kv,
 			None => return Ok(None),
 		};
 
 		if is_expired(kv.expire_ts) {
-			let write_opts = WriteOptions {
-				await_durable: false,
-			};
-			self.string_db
-				.delete_with_options(encoded_key, &write_opts)
-				.await?;
+			let mut batch = WriteBatch::new();
+			batch.delete(encoded_key);
+			self.write_batch(batch).await?;
 			return Ok(None);
 		}
 
@@ -196,13 +183,10 @@ impl Storage {
 		let key = StringKey::new(key);
 		let value = StringValue::new(Bytes::from(int_val.to_string()));
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
 		let put_opts = PutOptions::default();
-		self.string_db
-			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		self.write_batch(batch).await?;
 
 		Ok(int_val)
 	}
@@ -237,13 +221,10 @@ impl Storage {
 		let key = StringKey::new(key);
 		let value = StringValue::new(Bytes::from(int_val.to_string()));
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
 		let put_opts = PutOptions::default();
-		self.string_db
-			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		self.write_batch(batch).await?;
 
 		Ok(int_val)
 	}
@@ -271,13 +252,10 @@ impl Storage {
 		let key = StringKey::new(key);
 		let value = StringValue::new(Bytes::from(new_val));
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
 		let put_opts = PutOptions::default();
-		self.string_db
-			.put_with_options(key.encode(), value.encode(), &put_opts, &write_opts)
-			.await?;
+		let mut batch = WriteBatch::new();
+		batch.put_with_options(Segment::Meta.wrap(key.encode()), value.encode(), &put_opts);
+		self.write_batch(batch).await?;
 
 		Ok(len)
 	}

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -5,11 +5,9 @@ use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
 
 use crate::error::StorageError;
-use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
 use crate::string::meta::ZSetMetaValue;
-use crate::utils::zset_score_user_key_prefix;
 use crate::zset::member_key::MemberKey;
 use crate::zset::score_key::ScoreKey;
 
@@ -22,7 +20,7 @@ impl Storage {
 		elements: Vec<(f64, Bytes)>, // (score, member)
 	) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 		let put_opts = PutOptions::default();
 
 		// Get metadata first to obtain version
@@ -46,8 +44,7 @@ impl Storage {
 		let member_encoded_keys: Vec<_> = elements
 			.iter()
 			.map(|(_, member)| {
-				Segment::ZSet
-					.wrap(MemberKey::new(key.clone(), meta_val.version, member.clone()).encode())
+				MemberKey::new(key.clone(), meta_val.version, member.clone()).encode()
 			})
 			.collect();
 
@@ -88,16 +85,12 @@ impl Storage {
 					// Delete old ScoreKey
 					let old_score_key =
 						ScoreKey::new(key.clone(), meta_val.version, old_score, member.clone());
-					batch.delete(Segment::ZSet.wrap(old_score_key.encode()));
+					batch.delete(old_score_key.encode());
 
 					// Add new ScoreKey
 					let new_score_key =
 						ScoreKey::new(key.clone(), meta_val.version, score, member.clone());
-					batch.put_with_options(
-						Segment::ZSet.wrap(new_score_key.encode()),
-						Bytes::new(),
-						&put_opts,
-					);
+					batch.put_with_options(new_score_key.encode(), Bytes::new(), &put_opts);
 
 					// Update MemberKey
 					let encoded_score = ScoreKey::encode_score(score);
@@ -122,11 +115,7 @@ impl Storage {
 
 				// Add ScoreKey
 				let score_key = ScoreKey::new(key.clone(), meta_val.version, score, member);
-				batch.put_with_options(
-					Segment::ZSet.wrap(score_key.encode()),
-					Bytes::new(),
-					&put_opts,
-				);
+				batch.put_with_options(score_key.encode(), Bytes::new(), &put_opts);
 			}
 		}
 
@@ -165,7 +154,7 @@ impl Storage {
 
 			// We need to scan ScoreKeys.
 			// Key format: len(user_key) + user_key + b'S' + score + member
-			let prefix = Segment::ZSet.wrap(zset_score_user_key_prefix(&key, meta.version));
+			let prefix = ScoreKey::prefix(&key, meta.version);
 
 			let range = prefix.as_ref()..;
 			let mut stream = self.db.scan(range).await?;
@@ -218,11 +207,7 @@ impl Storage {
 		};
 
 		let member_key = MemberKey::new(key, meta_val.version, member);
-		if let Some(kv) = self
-			.db
-			.get_key_value(Segment::ZSet.wrap(member_key.encode()))
-			.await?
-		{
+		if let Some(kv) = self.db.get_key_value(member_key.encode()).await? {
 			// Val is encoded score (u64 BE)
 			let encoded_score = u64::from_be_bytes(kv.value[..8].try_into()?);
 			Ok(Some(ScoreKey::decode_score(encoded_score)))
@@ -235,7 +220,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn zrem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
+		let meta_encoded_key = meta_key.encode();
 
 		let mut meta_val = match self.get_meta::<ZSetMetaValue>(&key).await? {
 			Some(val) => val,
@@ -246,7 +231,7 @@ impl Storage {
 		let mut member_encoded_keys = Vec::with_capacity(members.len());
 		let fetch_futures = members.iter().map(|member| {
 			let member_key = MemberKey::new(key.clone(), meta_val.version, member.clone());
-			let encoded_key = Segment::ZSet.wrap(member_key.encode());
+			let encoded_key = member_key.encode();
 			member_encoded_keys.push(encoded_key.clone());
 			self.db.get_key_value(encoded_key)
 		});
@@ -274,7 +259,7 @@ impl Storage {
 				let encoded_score = u64::from_be_bytes(val[..8].try_into()?);
 				let score = ScoreKey::decode_score(encoded_score);
 				let score_key = ScoreKey::new(key.clone(), meta_val.version, score, member);
-				batch.delete(Segment::ZSet.wrap(score_key.encode()));
+				batch.delete(score_key.encode());
 
 				removed_count += 1;
 			}

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -28,7 +28,7 @@ impl Storage {
 		// Get metadata first to obtain version
 		let (mut meta_val, meta_missing) = match self.get_meta::<ZSetMetaValue>(&key).await? {
 			Some(val) => (val, false),
-			None => (ZSetMetaValue::new(self.next_generation(), 0), true),
+			None => (ZSetMetaValue::new(self.next_version(), 0), true),
 		};
 
 		// Deduplicate elements, keeping the LAST score for each member (Redis ZADD

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -28,7 +28,7 @@ impl Storage {
 		// Get metadata first to obtain version
 		let (mut meta_val, meta_missing) = match self.get_meta::<ZSetMetaValue>(&key).await? {
 			Some(val) => (val, false),
-			None => (ZSetMetaValue::new(0, 0), true),
+			None => (ZSetMetaValue::new(self.next_generation(), 0), true),
 		};
 
 		// Deduplicate elements, keeping the LAST score for each member (Redis ZADD
@@ -46,7 +46,8 @@ impl Storage {
 		let member_encoded_keys: Vec<_> = elements
 			.iter()
 			.map(|(_, member)| {
-				Segment::ZSet.wrap(MemberKey::new(key.clone(), member.clone()).encode())
+				Segment::ZSet
+					.wrap(MemberKey::new(key.clone(), meta_val.version, member.clone()).encode())
 			})
 			.collect();
 
@@ -64,7 +65,7 @@ impl Storage {
 				.collect::<Result<Vec<_>, _>>()?
 				.into_iter()
 				.map(|entry| match entry {
-					Some(kv) if kv.seq >= meta_val.version => Some(kv.value),
+					Some(kv) => Some(kv.value),
 					_ => None,
 				})
 				.collect()
@@ -85,11 +86,13 @@ impl Storage {
 				if old_score != score {
 					has_writes = true;
 					// Delete old ScoreKey
-					let old_score_key = ScoreKey::new(key.clone(), old_score, member.clone());
+					let old_score_key =
+						ScoreKey::new(key.clone(), meta_val.version, old_score, member.clone());
 					batch.delete(Segment::ZSet.wrap(old_score_key.encode()));
 
 					// Add new ScoreKey
-					let new_score_key = ScoreKey::new(key.clone(), score, member.clone());
+					let new_score_key =
+						ScoreKey::new(key.clone(), meta_val.version, score, member.clone());
 					batch.put_with_options(
 						Segment::ZSet.wrap(new_score_key.encode()),
 						Bytes::new(),
@@ -118,7 +121,7 @@ impl Storage {
 				);
 
 				// Add ScoreKey
-				let score_key = ScoreKey::new(key.clone(), score, member);
+				let score_key = ScoreKey::new(key.clone(), meta_val.version, score, member);
 				batch.put_with_options(
 					Segment::ZSet.wrap(score_key.encode()),
 					Bytes::new(),
@@ -128,20 +131,14 @@ impl Storage {
 		}
 
 		if has_writes {
-			self.write_batch_with_seq(|seq| {
-				if meta_missing && added_count > 0 {
-					meta_val.version = seq;
-				}
-				if added_count > 0 {
-					meta_val.len += added_count;
+			if added_count > 0 {
+				meta_val.len += added_count;
 
-					let put_opts = Storage::meta_put_opts(&meta_val);
+				let put_opts = Storage::meta_put_opts(&meta_val);
 
-					batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
-				}
-				batch
-			})
-			.await?;
+				batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
+			}
+			self.write_batch(batch).await?;
 		}
 
 		Ok(added_count)
@@ -168,7 +165,7 @@ impl Storage {
 
 			// We need to scan ScoreKeys.
 			// Key format: len(user_key) + user_key + b'S' + score + member
-			let prefix = Segment::ZSet.wrap(zset_score_user_key_prefix(&key));
+			let prefix = Segment::ZSet.wrap(zset_score_user_key_prefix(&key, meta.version));
 
 			let range = prefix.as_ref()..;
 			let mut stream = self.db.scan(range).await?;
@@ -185,10 +182,6 @@ impl Storage {
 				if !k.starts_with(&prefix) {
 					break;
 				}
-				if kv.seq < meta.version {
-					continue;
-				}
-
 				if current_idx >= start && current_idx <= stop {
 					// Extract member and score
 					// Key: len(user_key) + user_key + b'S' + score(8) + member
@@ -224,11 +217,11 @@ impl Storage {
 			return Ok(None);
 		};
 
-		let member_key = MemberKey::new(key, member);
+		let member_key = MemberKey::new(key, meta_val.version, member);
 		if let Some(kv) = self
 			.db
 			.get_key_value(Segment::ZSet.wrap(member_key.encode()))
-			.await? && kv.seq >= meta_val.version
+			.await?
 		{
 			// Val is encoded score (u64 BE)
 			let encoded_score = u64::from_be_bytes(kv.value[..8].try_into()?);
@@ -252,7 +245,7 @@ impl Storage {
 		// Fetch all member keys in parallel
 		let mut member_encoded_keys = Vec::with_capacity(members.len());
 		let fetch_futures = members.iter().map(|member| {
-			let member_key = MemberKey::new(key.clone(), member.clone());
+			let member_key = MemberKey::new(key.clone(), meta_val.version, member.clone());
 			let encoded_key = Segment::ZSet.wrap(member_key.encode());
 			member_encoded_keys.push(encoded_key.clone());
 			self.db.get_key_value(encoded_key)
@@ -263,7 +256,7 @@ impl Storage {
 		let old_values = old_values?
 			.into_iter()
 			.map(|entry| match entry {
-				Some(kv) if kv.seq >= meta_val.version => Some(kv.value),
+				Some(kv) => Some(kv.value),
 				_ => None,
 			})
 			.collect::<Vec<_>>();
@@ -280,7 +273,7 @@ impl Storage {
 				// Delete ScoreKey
 				let encoded_score = u64::from_be_bytes(val[..8].try_into()?);
 				let score = ScoreKey::decode_score(encoded_score);
-				let score_key = ScoreKey::new(key.clone(), score, member);
+				let score_key = ScoreKey::new(key.clone(), meta_val.version, score, member);
 				batch.delete(Segment::ZSet.wrap(score_key.encode()));
 
 				removed_count += 1;

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -78,8 +78,9 @@ impl Storage {
 
 			if let Some(old_score_bytes) = old_score_bytes {
 				// Update existing member
-				let old_score =
-					ScoreKey::decode_score(u64::from_be_bytes(old_score_bytes[..8].try_into()?));
+				let old_score = ScoreKey::decode_score(u64::from_be_bytes(
+					old_score_bytes.as_ref().try_into()?,
+				));
 				if old_score != score {
 					has_writes = true;
 					// Delete old ScoreKey
@@ -209,7 +210,7 @@ impl Storage {
 		let member_key = MemberKey::new(key, meta_val.version, member);
 		if let Some(kv) = self.db.get_key_value(member_key.encode()).await? {
 			// Val is encoded score (u64 BE)
-			let encoded_score = u64::from_be_bytes(kv.value[..8].try_into()?);
+			let encoded_score = u64::from_be_bytes(kv.value.as_ref().try_into()?);
 			Ok(Some(ScoreKey::decode_score(encoded_score)))
 		} else {
 			Ok(None)
@@ -227,14 +228,21 @@ impl Storage {
 			None => return Ok(0),
 		};
 
+		let mut seen_members = std::collections::HashSet::new();
+		let members = members
+			.into_iter()
+			.filter(|member| seen_members.insert(member.clone()))
+			.collect::<Vec<_>>();
+
 		// Fetch all member keys in parallel
 		let mut member_encoded_keys = Vec::with_capacity(members.len());
-		let fetch_futures = members.iter().map(|member| {
+		let mut fetch_futures = Vec::with_capacity(members.len());
+		for member in &members {
 			let member_key = MemberKey::new(key.clone(), meta_val.version, member.clone());
 			let encoded_key = member_key.encode();
 			member_encoded_keys.push(encoded_key.clone());
-			self.db.get_key_value(encoded_key)
-		});
+			fetch_futures.push(self.db.get_key_value(encoded_key));
+		}
 
 		let old_values: Result<Vec<_>, _> =
 			future::join_all(fetch_futures).await.into_iter().collect();
@@ -256,7 +264,7 @@ impl Storage {
 				batch.delete(&member_encoded_keys[idx]);
 
 				// Delete ScoreKey
-				let encoded_score = u64::from_be_bytes(val[..8].try_into()?);
+				let encoded_score = u64::from_be_bytes(val.as_ref().try_into()?);
 				let score = ScoreKey::decode_score(encoded_score);
 				let score_key = ScoreKey::new(key.clone(), meta_val.version, score, member);
 				batch.delete(score_key.encode());
@@ -486,6 +494,58 @@ mod tests {
 
 		let members = storage.zrange(key.clone(), 0, -1, false).await.unwrap();
 		assert_eq!(members, vec![Bytes::from("m1")]);
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_zrem_counts_duplicate_members_once() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("zset_zrem_duplicates");
+		let one = Bytes::from("one");
+		let two = Bytes::from("two");
+
+		storage
+			.zadd(key.clone(), vec![(1.0, one.clone()), (2.0, two.clone())])
+			.await
+			.unwrap();
+
+		let removed = storage
+			.zrem(key.clone(), vec![one.clone(), one])
+			.await
+			.unwrap();
+		assert_eq!(removed, 1);
+		assert_eq!(storage.zcard(key.clone()).await.unwrap(), 1);
+		assert_eq!(storage.zscore(key.clone(), two).await.unwrap(), Some(2.0));
+
+		let _ = std::fs::remove_dir_all(path);
+	}
+
+	#[tokio::test]
+	async fn test_zscore_and_zrem_return_error_for_short_score_value() {
+		let (storage, path) = get_storage().await;
+		let key = Bytes::from("zset_short_score");
+		let member = Bytes::from("one");
+
+		storage
+			.zadd(key.clone(), vec![(1.0, member.clone())])
+			.await
+			.unwrap();
+		let version = storage
+			.get_meta::<ZSetMetaValue>(&key)
+			.await
+			.unwrap()
+			.unwrap()
+			.version;
+		let member_key = MemberKey::new(key.clone(), version, member.clone()).encode();
+		storage
+			.db
+			.put(member_key, Bytes::from_static(b"bad"))
+			.await
+			.unwrap();
+
+		assert!(storage.zscore(key.clone(), member.clone()).await.is_err());
+		assert!(storage.zrem(key.clone(), vec![member]).await.is_err());
 
 		let _ = std::fs::remove_dir_all(path);
 	}

--- a/nimbis-storage/src/storage_zset.rs
+++ b/nimbis-storage/src/storage_zset.rs
@@ -3,9 +3,9 @@ use futures::future;
 use nimbis_macros::storage_lock;
 use slatedb::WriteBatch;
 use slatedb::config::PutOptions;
-use slatedb::config::WriteOptions;
 
 use crate::error::StorageError;
+use crate::segment::Segment;
 use crate::storage::Storage;
 use crate::string::meta::MetaKey;
 use crate::string::meta::ZSetMetaValue;
@@ -22,10 +22,7 @@ impl Storage {
 		elements: Vec<(f64, Bytes)>, // (score, member)
 	) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 		let put_opts = PutOptions::default();
 
 		// Get metadata first to obtain version
@@ -48,7 +45,9 @@ impl Storage {
 		// Unconditionally encode all member keys since we need them for insertion
 		let member_encoded_keys: Vec<_> = elements
 			.iter()
-			.map(|(_, member)| MemberKey::new(key.clone(), member.clone()).encode())
+			.map(|(_, member)| {
+				Segment::ZSet.wrap(MemberKey::new(key.clone(), member.clone()).encode())
+			})
 			.collect();
 
 		let old_values: Vec<_> = if meta_missing {
@@ -57,7 +56,7 @@ impl Storage {
 			// Fetch all existing members concurrently
 			let member_futs = member_encoded_keys
 				.iter()
-				.map(|enc| self.zset_db.get_key_value(enc.clone()));
+				.map(|enc| self.db.get_key_value(enc.clone()));
 
 			future::join_all(member_futs)
 				.await
@@ -72,8 +71,6 @@ impl Storage {
 		};
 
 		let mut added_count = 0;
-		let mut first_new_member_key: Option<Bytes> = None;
-		// Use WriteBatch to ensure atomicity of all zset operations
 		let mut batch = WriteBatch::new();
 		let mut has_writes = false;
 
@@ -89,11 +86,15 @@ impl Storage {
 					has_writes = true;
 					// Delete old ScoreKey
 					let old_score_key = ScoreKey::new(key.clone(), old_score, member.clone());
-					batch.delete(old_score_key.encode());
+					batch.delete(Segment::ZSet.wrap(old_score_key.encode()));
 
 					// Add new ScoreKey
 					let new_score_key = ScoreKey::new(key.clone(), score, member.clone());
-					batch.put_with_options(new_score_key.encode(), Bytes::new(), &put_opts);
+					batch.put_with_options(
+						Segment::ZSet.wrap(new_score_key.encode()),
+						Bytes::new(),
+						&put_opts,
+					);
 
 					// Update MemberKey
 					let encoded_score = ScoreKey::encode_score(score);
@@ -107,9 +108,6 @@ impl Storage {
 				has_writes = true;
 				// New member
 				added_count += 1;
-				if first_new_member_key.is_none() {
-					first_new_member_key = Some(encoded_member_key.clone());
-				}
 
 				// Add MemberKey
 				let encoded_score = ScoreKey::encode_score(score);
@@ -121,38 +119,29 @@ impl Storage {
 
 				// Add ScoreKey
 				let score_key = ScoreKey::new(key.clone(), score, member);
-				batch.put_with_options(score_key.encode(), Bytes::new(), &put_opts);
+				batch.put_with_options(
+					Segment::ZSet.wrap(score_key.encode()),
+					Bytes::new(),
+					&put_opts,
+				);
 			}
 		}
 
 		if has_writes {
-			self.zset_db.write_with_options(batch, &write_opts).await?;
-		}
+			self.write_batch_with_seq(|seq| {
+				if meta_missing && added_count > 0 {
+					meta_val.version = seq;
+				}
+				if added_count > 0 {
+					meta_val.len += added_count;
 
-		if meta_missing && added_count > 0 {
-			let Some(first_key) = first_new_member_key else {
-				return Err(StorageError::DataInconsistency {
-					message: "missing first new zset member key after write".to_string(),
-				});
-			};
-			let first_entry = self
-				.zset_db
-				.get_key_value(first_key)
-				.await?
-				.ok_or_else(|| StorageError::DataInconsistency {
-					message: "failed to read first new zset member after write".to_string(),
-				})?;
-			meta_val.version = first_entry.seq;
-		}
+					let put_opts = Storage::meta_put_opts(&meta_val);
 
-		if added_count > 0 {
-			meta_val.len += added_count;
-
-			let put_opts = Storage::meta_put_opts(&meta_val);
-
-			self.string_db
-				.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-				.await?;
+					batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
+				}
+				batch
+			})
+			.await?;
 		}
 
 		Ok(added_count)
@@ -179,10 +168,10 @@ impl Storage {
 
 			// We need to scan ScoreKeys.
 			// Key format: len(user_key) + user_key + b'S' + score + member
-			let prefix = zset_score_user_key_prefix(&key);
+			let prefix = Segment::ZSet.wrap(zset_score_user_key_prefix(&key));
 
 			let range = prefix.as_ref()..;
-			let mut stream = self.zset_db.scan(range).await?;
+			let mut stream = self.db.scan(range).await?;
 
 			let mut result = Vec::new();
 			let mut current_idx = 0;
@@ -236,8 +225,10 @@ impl Storage {
 		};
 
 		let member_key = MemberKey::new(key, member);
-		if let Some(kv) = self.zset_db.get_key_value(member_key.encode()).await?
-			&& kv.seq >= meta_val.version
+		if let Some(kv) = self
+			.db
+			.get_key_value(Segment::ZSet.wrap(member_key.encode()))
+			.await? && kv.seq >= meta_val.version
 		{
 			// Val is encoded score (u64 BE)
 			let encoded_score = u64::from_be_bytes(kv.value[..8].try_into()?);
@@ -251,7 +242,7 @@ impl Storage {
 	#[fastrace::trace]
 	pub async fn zrem(&self, key: Bytes, members: Vec<Bytes>) -> Result<u64, StorageError> {
 		let meta_key = MetaKey::new(key.clone());
-		let meta_encoded_key = meta_key.encode();
+		let meta_encoded_key = Segment::Meta.wrap(meta_key.encode());
 
 		let mut meta_val = match self.get_meta::<ZSetMetaValue>(&key).await? {
 			Some(val) => val,
@@ -262,9 +253,9 @@ impl Storage {
 		let mut member_encoded_keys = Vec::with_capacity(members.len());
 		let fetch_futures = members.iter().map(|member| {
 			let member_key = MemberKey::new(key.clone(), member.clone());
-			let encoded_key = member_key.encode();
+			let encoded_key = Segment::ZSet.wrap(member_key.encode());
 			member_encoded_keys.push(encoded_key.clone());
-			self.zset_db.get_key_value(encoded_key)
+			self.db.get_key_value(encoded_key)
 		});
 
 		let old_values: Result<Vec<_>, _> =
@@ -290,7 +281,7 @@ impl Storage {
 				let encoded_score = u64::from_be_bytes(val[..8].try_into()?);
 				let score = ScoreKey::decode_score(encoded_score);
 				let score_key = ScoreKey::new(key.clone(), score, member);
-				batch.delete(score_key.encode());
+				batch.delete(Segment::ZSet.wrap(score_key.encode()));
 
 				removed_count += 1;
 			}
@@ -300,24 +291,14 @@ impl Storage {
 			return Ok(0);
 		}
 
-		let write_opts = WriteOptions {
-			await_durable: false,
-		};
-
-		// Execute all delete operations atomically
-		self.zset_db.write_with_options(batch, &write_opts).await?;
-
 		meta_val.len -= removed_count;
 		if meta_val.len == 0 {
-			self.string_db
-				.delete_with_options(meta_encoded_key, &write_opts)
-				.await?;
+			batch.delete(meta_encoded_key);
 		} else {
 			let put_opts = Storage::meta_put_opts(&meta_val);
-			self.string_db
-				.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts, &write_opts)
-				.await?;
+			batch.put_with_options(meta_encoded_key, meta_val.encode(), &put_opts);
 		}
+		self.write_batch(batch).await?;
 
 		Ok(removed_count)
 	}

--- a/nimbis-storage/src/string/key.rs
+++ b/nimbis-storage/src/string/key.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 
 use crate::error::DecoderError;
+use crate::segment::META_PREFIX;
 
 #[derive(Debug, PartialEq)]
 pub struct StringKey {
@@ -18,17 +19,21 @@ impl StringKey {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut buf = BytesMut::with_capacity(2 + self.user_key.len());
+		let mut buf = BytesMut::with_capacity(1 + 2 + self.user_key.len());
+		buf.put_u8(META_PREFIX);
 		buf.put_u16(self.user_key.len() as u16);
 		buf.extend_from_slice(&self.user_key);
 		buf.freeze()
 	}
 
 	pub fn decode(bytes: &[u8]) -> Result<Self, DecoderError> {
-		if bytes.len() < 2 {
+		if bytes.len() < 3 {
 			return Err(DecoderError::InvalidLength);
 		}
-		let mut buf = bytes;
+		if bytes[0] != META_PREFIX {
+			return Err(DecoderError::InvalidType);
+		}
+		let mut buf = &bytes[1..];
 		let len = buf.get_u16() as usize;
 		if buf.len() < len {
 			return Err(DecoderError::InvalidLength);
@@ -45,8 +50,8 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	#[case("mykey", b"\x00\x05mykey")]
-	#[case("something else", b"\x00\x0esomething else")]
+	#[case("mykey", b"m\x00\x05mykey")]
+	#[case("something else", b"m\x00\x0esomething else")]
 	fn test_encode(#[case] key: &str, #[case] expected: &[u8]) {
 		let key = StringKey::new(Bytes::copy_from_slice(key.as_bytes()));
 		let encoded = key.encode();
@@ -54,8 +59,8 @@ mod tests {
 	}
 
 	#[rstest]
-	#[case(b"\x00\x05mykey", "mykey")]
-	#[case(b"\x00\x0esomething else", "something else")]
+	#[case(b"m\x00\x05mykey", "mykey")]
+	#[case(b"m\x00\x0esomething else", "something else")]
 	fn test_decode(#[case] encoded: &[u8], #[case] expected: &str) {
 		let key = StringKey::decode(encoded).unwrap();
 		assert_eq!(key.user_key, Bytes::copy_from_slice(expected.as_bytes()));

--- a/nimbis-storage/src/string/meta.rs
+++ b/nimbis-storage/src/string/meta.rs
@@ -7,6 +7,7 @@ use bytes::BytesMut;
 
 use crate::data_type::DataType;
 use crate::error::DecoderError;
+use crate::segment::META_PREFIX;
 use crate::string::value::StringValue;
 
 /// Trait for values stored in the string database that carry TTL and type
@@ -82,7 +83,8 @@ impl MetaKey {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		let mut buf = BytesMut::with_capacity(2 + self.user_key.len());
+		let mut buf = BytesMut::with_capacity(1 + 2 + self.user_key.len());
+		buf.put_u8(META_PREFIX);
 		buf.put_u16(self.user_key.len() as u16);
 		buf.extend_from_slice(&self.user_key);
 		buf.freeze()
@@ -528,8 +530,8 @@ mod tests {
 	use super::*;
 
 	#[rstest]
-	#[case("mykey", b"\x00\x05mykey")]
-	#[case("", b"\x00\x00")]
+	#[case("mykey", b"m\x00\x05mykey")]
+	#[case("", b"m\x00\x00")]
 	fn test_meta_key_encode(#[case] key: &str, #[case] expected: &[u8]) {
 		let meta_key = MetaKey::new(Bytes::copy_from_slice(key.as_bytes()));
 		assert_eq!(&meta_key.encode()[..], expected);

--- a/nimbis-storage/src/utils.rs
+++ b/nimbis-storage/src/utils.rs
@@ -1,41 +1,10 @@
 use bytes::Buf;
-use bytes::BufMut;
 use bytes::Bytes;
-use bytes::BytesMut;
 use chrono::Utc;
 
 /// Check if a given expire_ts (milliseconds since epoch) has passed.
 pub fn is_expired(expire_ts: Option<i64>) -> bool {
 	expire_ts.is_some_and(|ts| ts <= Utc::now().timestamp_millis())
-}
-
-/// Build the common storage prefix: len(user_key) (u16 BE) + user_key.
-pub fn user_key_prefix(key: &Bytes) -> Bytes {
-	let mut prefix = BytesMut::with_capacity(2 + key.len());
-	prefix.put_u16(key.len() as u16);
-	prefix.extend_from_slice(key);
-	prefix.freeze()
-}
-
-/// Build the current collection version prefix:
-/// len(user_key) (u16 BE) + user_key + version (u64 BE).
-pub fn collection_version_prefix(key: &Bytes, version: u64) -> Bytes {
-	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8);
-	prefix.put_u16(key.len() as u16);
-	prefix.extend_from_slice(key);
-	prefix.put_u64(version);
-	prefix.freeze()
-}
-
-/// Build zset score-key prefix:
-/// len(user_key) (u16 BE) + user_key + version (u64 BE) + b'S'.
-pub fn zset_score_user_key_prefix(key: &Bytes, version: u64) -> Bytes {
-	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8 + 1);
-	prefix.put_u16(key.len() as u16);
-	prefix.extend_from_slice(key);
-	prefix.put_u64(version);
-	prefix.put_u8(b'S');
-	prefix.freeze()
 }
 
 /// Decode the common collection sub-key header:

--- a/nimbis-storage/src/utils.rs
+++ b/nimbis-storage/src/utils.rs
@@ -1,3 +1,4 @@
+use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
@@ -16,12 +17,40 @@ pub fn user_key_prefix(key: &Bytes) -> Bytes {
 	prefix.freeze()
 }
 
-/// Build zset score-key prefix:
-/// len(user_key) (u16 BE) + user_key + b'S'.
-pub fn zset_score_user_key_prefix(key: &Bytes) -> Bytes {
-	let mut prefix = BytesMut::with_capacity(2 + key.len() + 1);
+/// Build the current collection generation prefix:
+/// len(user_key) (u16 BE) + user_key + generation (u64 BE).
+pub fn collection_generation_prefix(key: &Bytes, generation: u64) -> Bytes {
+	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8);
 	prefix.put_u16(key.len() as u16);
 	prefix.extend_from_slice(key);
+	prefix.put_u64(generation);
+	prefix.freeze()
+}
+
+/// Build zset score-key prefix:
+/// len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'S'.
+pub fn zset_score_user_key_prefix(key: &Bytes, generation: u64) -> Bytes {
+	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8 + 1);
+	prefix.put_u16(key.len() as u16);
+	prefix.extend_from_slice(key);
+	prefix.put_u64(generation);
 	prefix.put_u8(b'S');
 	prefix.freeze()
+}
+
+/// Decode the common collection sub-key header:
+/// len(user_key) (u16 BE) + user_key + generation (u64 BE) + ...
+pub fn decode_collection_generation(payload: &[u8]) -> Option<(Bytes, u64)> {
+	if payload.len() < 2 {
+		return None;
+	}
+	let mut buf = payload;
+	let key_len = buf.get_u16() as usize;
+	if buf.len() < key_len + 8 {
+		return None;
+	}
+	let user_key = Bytes::copy_from_slice(&buf[..key_len]);
+	buf.advance(key_len);
+	let generation = buf.get_u64();
+	Some((user_key, generation))
 }

--- a/nimbis-storage/src/utils.rs
+++ b/nimbis-storage/src/utils.rs
@@ -17,30 +17,30 @@ pub fn user_key_prefix(key: &Bytes) -> Bytes {
 	prefix.freeze()
 }
 
-/// Build the current collection generation prefix:
-/// len(user_key) (u16 BE) + user_key + generation (u64 BE).
-pub fn collection_generation_prefix(key: &Bytes, generation: u64) -> Bytes {
+/// Build the current collection version prefix:
+/// len(user_key) (u16 BE) + user_key + version (u64 BE).
+pub fn collection_version_prefix(key: &Bytes, version: u64) -> Bytes {
 	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8);
 	prefix.put_u16(key.len() as u16);
 	prefix.extend_from_slice(key);
-	prefix.put_u64(generation);
+	prefix.put_u64(version);
 	prefix.freeze()
 }
 
 /// Build zset score-key prefix:
-/// len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'S'.
-pub fn zset_score_user_key_prefix(key: &Bytes, generation: u64) -> Bytes {
+/// len(user_key) (u16 BE) + user_key + version (u64 BE) + b'S'.
+pub fn zset_score_user_key_prefix(key: &Bytes, version: u64) -> Bytes {
 	let mut prefix = BytesMut::with_capacity(2 + key.len() + 8 + 1);
 	prefix.put_u16(key.len() as u16);
 	prefix.extend_from_slice(key);
-	prefix.put_u64(generation);
+	prefix.put_u64(version);
 	prefix.put_u8(b'S');
 	prefix.freeze()
 }
 
 /// Decode the common collection sub-key header:
-/// len(user_key) (u16 BE) + user_key + generation (u64 BE) + ...
-pub fn decode_collection_generation(payload: &[u8]) -> Option<(Bytes, u64)> {
+/// len(user_key) (u16 BE) + user_key + version (u64 BE) + ...
+pub fn decode_collection_version(payload: &[u8]) -> Option<(Bytes, u64)> {
 	if payload.len() < 2 {
 		return None;
 	}
@@ -51,6 +51,6 @@ pub fn decode_collection_generation(payload: &[u8]) -> Option<(Bytes, u64)> {
 	}
 	let user_key = Bytes::copy_from_slice(&buf[..key_len]);
 	buf.advance(key_len);
-	let generation = buf.get_u64();
-	Some((user_key, generation))
+	let version = buf.get_u64();
+	Some((user_key, version))
 }

--- a/nimbis-storage/src/version.rs
+++ b/nimbis-storage/src/version.rs
@@ -1,12 +1,12 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
-/// Generates monotonically increasing collection generations.
+/// Generates monotonically increasing collection versions.
 ///
 /// The layout follows Kvrocks' timestamp-plus-counter style:
 /// high 53 bits are microseconds since epoch, low 11 bits are a per-process
 /// counter. If the clock does not move forward, this falls back to `last + 1`
-/// to keep generations unique and monotonic in this process.
+/// to keep versions unique and monotonic in this process.
 pub struct VersionGenerator {
 	last_version: AtomicU64,
 }

--- a/nimbis-storage/src/version.rs
+++ b/nimbis-storage/src/version.rs
@@ -1,28 +1,41 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
-/// Generates monotonically increasing versions based on seconds timestamps.
-/// If the current timestamp is not greater than the last generated version,
-/// it increments the last version by 1 to guarantee monotonicity.
+/// Generates monotonically increasing collection generations.
+///
+/// The layout follows Kvrocks' timestamp-plus-counter style:
+/// high 53 bits are microseconds since epoch, low 11 bits are a per-process
+/// counter. If the clock does not move forward, this falls back to `last + 1`
+/// to keep generations unique and monotonic in this process.
 pub struct VersionGenerator {
 	last_version: AtomicU64,
 }
 
 impl VersionGenerator {
+	pub const COUNTER_BITS: u64 = 11;
+	pub const COUNTER_MASK: u64 = (1 << Self::COUNTER_BITS) - 1;
+
 	pub fn new() -> Self {
+		let timestamp = Self::timestamp_micros();
+		let seed = timestamp & Self::COUNTER_MASK;
 		Self {
-			last_version: AtomicU64::new(0),
+			last_version: AtomicU64::new((timestamp << Self::COUNTER_BITS) | seed),
 		}
 	}
 
 	/// Generates a new version that is guaranteed to be greater than any
 	/// previously generated version from this generator.
 	pub fn next(&self) -> u64 {
-		let now = chrono::Utc::now().timestamp() as u64;
-
 		loop {
+			let now = Self::timestamp_micros();
 			let last = self.last_version.load(Ordering::Acquire);
-			let next = if now > last { now } else { last + 1 };
+			let next_counter = (last.wrapping_add(1)) & Self::COUNTER_MASK;
+			let timestamp_candidate = (now << Self::COUNTER_BITS) | next_counter;
+			let next = if timestamp_candidate > last {
+				timestamp_candidate
+			} else {
+				last + 1
+			};
 
 			if self
 				.last_version
@@ -33,6 +46,10 @@ impl VersionGenerator {
 			}
 			// CAS failed, another thread updated; retry
 		}
+	}
+
+	fn timestamp_micros() -> u64 {
+		chrono::Utc::now().timestamp_micros().max(0) as u64
 	}
 }
 
@@ -55,6 +72,18 @@ mod tests {
 			assert!(v > prev, "Version should be strictly increasing");
 			prev = v;
 		}
+	}
+
+	#[test]
+	fn test_version_layout_uses_11_bit_counter() {
+		let generator = VersionGenerator::new();
+		let version = generator.next();
+
+		assert_ne!(version >> 11, 0);
+		assert_eq!(
+			version & !VersionGenerator::COUNTER_MASK,
+			(version >> 11) << 11
+		);
 	}
 
 	#[test]

--- a/nimbis-storage/src/zset/member_key.rs
+++ b/nimbis-storage/src/zset/member_key.rs
@@ -2,6 +2,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 
+use crate::segment::ZSET_PREFIX;
+
 #[derive(Debug, PartialEq)]
 pub struct MemberKey {
 	user_key: Bytes,
@@ -19,13 +21,14 @@ impl MemberKey {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + b'M' +
-		// len(member) (u32 BE) + member
+		// Key format: b'z' + len(user_key) (u16 BE) + user_key + version (u64 BE) +
+		// b'M' + len(member) (u32 BE) + member
 		let user_key_len = self.user_key.len() as u16;
 		let member_len = self.member.len() as u32;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 4 + self.member.len());
+			BytesMut::with_capacity(1 + 2 + self.user_key.len() + 8 + 1 + 4 + self.member.len());
+		bytes.put_u8(ZSET_PREFIX);
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
 		bytes.put_u64(self.version);
@@ -51,10 +54,11 @@ mod tests {
 		let key = Bytes::from("myzset");
 		let member = Bytes::from("member");
 		let encoded = MemberKey::new(key.clone(), version, member).encode();
-		let version_start = 2 + key.len();
+		let version_start = 3 + key.len();
 
-		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
-		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
+		assert_eq!(encoded[0], b'z');
+		assert_eq!(&encoded[1..3], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[3..3 + key.len()], key.as_ref());
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
 			&version.to_be_bytes()

--- a/nimbis-storage/src/zset/member_key.rs
+++ b/nimbis-storage/src/zset/member_key.rs
@@ -5,27 +5,30 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct MemberKey {
 	user_key: Bytes,
+	generation: u64,
 	member: Bytes,
 }
 
 impl MemberKey {
-	pub fn new(user_key: impl Into<Bytes>, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, generation: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
+			generation,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + b'M' +
+		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'M' +
 		// len(member) (u32 BE) + member
 		let user_key_len = self.user_key.len() as u16;
 		let member_len = self.member.len() as u32;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 1 + 4 + self.member.len());
+			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 4 + self.member.len());
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.generation);
 		bytes.put_u8(b'M');
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
@@ -35,5 +38,27 @@ impl MemberKey {
 	/// Returns the user_key from this member key.
 	pub fn user_key(&self) -> &Bytes {
 		&self.user_key
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_zset_member_key_encode_includes_generation() {
+		let generation = 0x0102_0304_0506_0708;
+		let key = Bytes::from("myzset");
+		let member = Bytes::from("member");
+		let encoded = MemberKey::new(key.clone(), generation, member).encode();
+		let generation_start = 2 + key.len();
+
+		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
+		assert_eq!(
+			&encoded[generation_start..generation_start + 8],
+			&generation.to_be_bytes()
+		);
+		assert_eq!(encoded[generation_start + 8], b'M');
 	}
 }

--- a/nimbis-storage/src/zset/member_key.rs
+++ b/nimbis-storage/src/zset/member_key.rs
@@ -5,21 +5,21 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct MemberKey {
 	user_key: Bytes,
-	generation: u64,
+	version: u64,
 	member: Bytes,
 }
 
 impl MemberKey {
-	pub fn new(user_key: impl Into<Bytes>, generation: u64, member: impl Into<Bytes>) -> Self {
+	pub fn new(user_key: impl Into<Bytes>, version: u64, member: impl Into<Bytes>) -> Self {
 		Self {
 			user_key: user_key.into(),
-			generation,
+			version,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'M' +
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + b'M' +
 		// len(member) (u32 BE) + member
 		let user_key_len = self.user_key.len() as u16;
 		let member_len = self.member.len() as u32;
@@ -28,7 +28,7 @@ impl MemberKey {
 			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 4 + self.member.len());
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
-		bytes.put_u64(self.generation);
+		bytes.put_u64(self.version);
 		bytes.put_u8(b'M');
 		bytes.put_u32(member_len);
 		bytes.extend_from_slice(&self.member);
@@ -46,19 +46,19 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_zset_member_key_encode_includes_generation() {
-		let generation = 0x0102_0304_0506_0708;
+	fn test_zset_member_key_encode_includes_version() {
+		let version = 0x0102_0304_0506_0708;
 		let key = Bytes::from("myzset");
 		let member = Bytes::from("member");
-		let encoded = MemberKey::new(key.clone(), generation, member).encode();
-		let generation_start = 2 + key.len();
+		let encoded = MemberKey::new(key.clone(), version, member).encode();
+		let version_start = 2 + key.len();
 
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
 		assert_eq!(
-			&encoded[generation_start..generation_start + 8],
-			&generation.to_be_bytes()
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
 		);
-		assert_eq!(encoded[generation_start + 8], b'M');
+		assert_eq!(encoded[version_start + 8], b'M');
 	}
 }

--- a/nimbis-storage/src/zset/score_key.rs
+++ b/nimbis-storage/src/zset/score_key.rs
@@ -5,21 +5,28 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct ScoreKey {
 	user_key: Bytes,
+	generation: u64,
 	score: f64,
 	member: Bytes,
 }
 
 impl ScoreKey {
-	pub fn new(user_key: impl Into<Bytes>, score: f64, member: impl Into<Bytes>) -> Self {
+	pub fn new(
+		user_key: impl Into<Bytes>,
+		generation: u64,
+		score: f64,
+		member: impl Into<Bytes>,
+	) -> Self {
 		Self {
 			user_key: user_key.into(),
+			generation,
 			score,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + b'S' +
+		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'S' +
 		// score (u64 big endian, bit flipped) + member We use a custom encoding for
 		// f64 to ensure correct sorting order. IEEE 754 floats don't sort correctly
 		// when treated as bytes (especially negative numbers). A common trick is to
@@ -37,9 +44,10 @@ impl ScoreKey {
 		let user_key_len = self.user_key.len() as u16;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 1 + 8 + self.member.len());
+			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 8 + self.member.len());
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
+		bytes.put_u64(self.generation);
 		bytes.put_u8(b'S');
 		bytes.put_u64(encoded_score);
 		bytes.extend_from_slice(&self.member);
@@ -154,5 +162,21 @@ mod tests {
 	fn test_negative_has_msb_unset(#[case] score: f64) {
 		let encoded = ScoreKey::encode_score(score);
 		assert_eq!(encoded & 0x8000_0000_0000_0000, 0);
+	}
+
+	#[test]
+	fn test_zset_score_key_encode_includes_generation() {
+		let generation = 0x0102_0304_0506_0708;
+		let key = Bytes::from("myzset");
+		let encoded = ScoreKey::new(key.clone(), generation, 1.5, Bytes::from("member")).encode();
+		let generation_start = 2 + key.len();
+
+		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
+		assert_eq!(
+			&encoded[generation_start..generation_start + 8],
+			&generation.to_be_bytes()
+		);
+		assert_eq!(encoded[generation_start + 8], b'S');
 	}
 }

--- a/nimbis-storage/src/zset/score_key.rs
+++ b/nimbis-storage/src/zset/score_key.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 #[derive(Debug, PartialEq)]
 pub struct ScoreKey {
 	user_key: Bytes,
-	generation: u64,
+	version: u64,
 	score: f64,
 	member: Bytes,
 }
@@ -13,20 +13,20 @@ pub struct ScoreKey {
 impl ScoreKey {
 	pub fn new(
 		user_key: impl Into<Bytes>,
-		generation: u64,
+		version: u64,
 		score: f64,
 		member: impl Into<Bytes>,
 	) -> Self {
 		Self {
 			user_key: user_key.into(),
-			generation,
+			version,
 			score,
 			member: member.into(),
 		}
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + generation (u64 BE) + b'S' +
+		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + b'S' +
 		// score (u64 big endian, bit flipped) + member We use a custom encoding for
 		// f64 to ensure correct sorting order. IEEE 754 floats don't sort correctly
 		// when treated as bytes (especially negative numbers). A common trick is to
@@ -47,7 +47,7 @@ impl ScoreKey {
 			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 8 + self.member.len());
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
-		bytes.put_u64(self.generation);
+		bytes.put_u64(self.version);
 		bytes.put_u8(b'S');
 		bytes.put_u64(encoded_score);
 		bytes.extend_from_slice(&self.member);
@@ -165,18 +165,18 @@ mod tests {
 	}
 
 	#[test]
-	fn test_zset_score_key_encode_includes_generation() {
-		let generation = 0x0102_0304_0506_0708;
+	fn test_zset_score_key_encode_includes_version() {
+		let version = 0x0102_0304_0506_0708;
 		let key = Bytes::from("myzset");
-		let encoded = ScoreKey::new(key.clone(), generation, 1.5, Bytes::from("member")).encode();
-		let generation_start = 2 + key.len();
+		let encoded = ScoreKey::new(key.clone(), version, 1.5, Bytes::from("member")).encode();
+		let version_start = 2 + key.len();
 
 		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
 		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
 		assert_eq!(
-			&encoded[generation_start..generation_start + 8],
-			&generation.to_be_bytes()
+			&encoded[version_start..version_start + 8],
+			&version.to_be_bytes()
 		);
-		assert_eq!(encoded[generation_start + 8], b'S');
+		assert_eq!(encoded[version_start + 8], b'S');
 	}
 }

--- a/nimbis-storage/src/zset/score_key.rs
+++ b/nimbis-storage/src/zset/score_key.rs
@@ -2,6 +2,8 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 
+use crate::segment::ZSET_PREFIX;
+
 #[derive(Debug, PartialEq)]
 pub struct ScoreKey {
 	user_key: Bytes,
@@ -26,9 +28,9 @@ impl ScoreKey {
 	}
 
 	pub fn encode(&self) -> Bytes {
-		// Key format: len(user_key) (u16 BE) + user_key + version (u64 BE) + b'S' +
-		// score (u64 big endian, bit flipped) + member We use a custom encoding for
-		// f64 to ensure correct sorting order. IEEE 754 floats don't sort correctly
+		// Key format: b'z' + len(user_key) (u16 BE) + user_key + version (u64 BE) +
+		// b'S' + score (u64 big endian, bit flipped) + member We use a custom encoding
+		// for f64 to ensure correct sorting order. IEEE 754 floats don't sort correctly
 		// when treated as bytes (especially negative numbers). A common trick is to
 		// flip the sign bit if positive, or flip all bits if negative. However, for
 		// simplicity and standard practice in key-value stores (like CockroachDB or
@@ -44,13 +46,24 @@ impl ScoreKey {
 		let user_key_len = self.user_key.len() as u16;
 
 		let mut bytes =
-			BytesMut::with_capacity(2 + self.user_key.len() + 8 + 1 + 8 + self.member.len());
+			BytesMut::with_capacity(1 + 2 + self.user_key.len() + 8 + 1 + 8 + self.member.len());
+		bytes.put_u8(ZSET_PREFIX);
 		bytes.put_u16(user_key_len);
 		bytes.extend_from_slice(&self.user_key);
 		bytes.put_u64(self.version);
 		bytes.put_u8(b'S');
 		bytes.put_u64(encoded_score);
 		bytes.extend_from_slice(&self.member);
+		bytes.freeze()
+	}
+
+	pub fn prefix(user_key: &Bytes, version: u64) -> Bytes {
+		let mut bytes = BytesMut::with_capacity(1 + 2 + user_key.len() + 8 + 1);
+		bytes.put_u8(ZSET_PREFIX);
+		bytes.put_u16(user_key.len() as u16);
+		bytes.extend_from_slice(user_key);
+		bytes.put_u64(version);
+		bytes.put_u8(b'S');
 		bytes.freeze()
 	}
 
@@ -169,10 +182,11 @@ mod tests {
 		let version = 0x0102_0304_0506_0708;
 		let key = Bytes::from("myzset");
 		let encoded = ScoreKey::new(key.clone(), version, 1.5, Bytes::from("member")).encode();
-		let version_start = 2 + key.len();
+		let version_start = 3 + key.len();
 
-		assert_eq!(&encoded[..2], &(key.len() as u16).to_be_bytes());
-		assert_eq!(&encoded[2..2 + key.len()], key.as_ref());
+		assert_eq!(encoded[0], b'z');
+		assert_eq!(&encoded[1..3], &(key.len() as u16).to_be_bytes());
+		assert_eq!(&encoded[3..3 + key.len()], key.as_ref());
 		assert_eq!(
 			&encoded[version_start..version_start + 8],
 			&version.to_be_bytes()

--- a/nimbis-storage/tests/test_segments.rs
+++ b/nimbis-storage/tests/test_segments.rs
@@ -1,0 +1,34 @@
+use bytes::Bytes;
+use nimbis_storage::segment::NimbisSegmentExtractor;
+use nimbis_storage::segment::Segment;
+use slatedb::PrefixExtractor;
+use slatedb::PrefixTarget;
+
+#[test]
+fn segment_keys_are_one_byte_prefixes_over_existing_payloads() {
+	let payload = Bytes::from_static(b"\x00\x04user\x00\x05field");
+	let encoded = Segment::Hash.wrap(payload.clone());
+
+	assert_eq!(encoded, Bytes::from_static(b"h\x00\x04user\x00\x05field"));
+	assert_eq!(Segment::Hash.strip(&encoded), Some(payload));
+	assert_eq!(Segment::Set.strip(&encoded), None);
+}
+
+#[test]
+fn segment_extractor_routes_by_first_byte() {
+	let extractor = NimbisSegmentExtractor;
+
+	assert_eq!(extractor.name(), "nimbis-storage-segment-v1");
+	assert_eq!(
+		extractor.prefix_len(&PrefixTarget::Point(Bytes::from_static(b"h\x00\x04user"))),
+		Some(1)
+	);
+	assert_eq!(
+		extractor.prefix_len(&PrefixTarget::Prefix(Bytes::from_static(b"h"))),
+		Some(1)
+	);
+	assert_eq!(
+		extractor.prefix_len(&PrefixTarget::Prefix(Bytes::new())),
+		None
+	);
+}

--- a/nimbis-storage/tests/test_segments.rs
+++ b/nimbis-storage/tests/test_segments.rs
@@ -1,17 +1,27 @@
 use bytes::Bytes;
+use nimbis_storage::hash::field_key::HashFieldKey;
+use nimbis_storage::segment::HASH_PREFIX;
 use nimbis_storage::segment::NimbisSegmentExtractor;
-use nimbis_storage::segment::Segment;
+use nimbis_storage::segment::SET_PREFIX;
+use nimbis_storage::set::member_key::SetMemberKey;
 use slatedb::PrefixExtractor;
 use slatedb::PrefixTarget;
 
 #[test]
-fn segment_keys_are_one_byte_prefixes_over_existing_payloads() {
-	let payload = Bytes::from_static(b"\x00\x04user\x00\x05field");
-	let encoded = Segment::Hash.wrap(payload.clone());
+fn typed_keys_encode_segment_prefix_directly() {
+	let hash_key =
+		HashFieldKey::new(Bytes::from_static(b"user"), 7, Bytes::from_static(b"field")).encode();
+	let set_key = SetMemberKey::new(
+		Bytes::from_static(b"user"),
+		7,
+		Bytes::from_static(b"member"),
+	)
+	.encode();
 
-	assert_eq!(encoded, Bytes::from_static(b"h\x00\x04user\x00\x05field"));
-	assert_eq!(Segment::Hash.strip(&encoded), Some(payload));
-	assert_eq!(Segment::Set.strip(&encoded), None);
+	assert_eq!(hash_key[0], HASH_PREFIX);
+	assert_eq!(set_key[0], SET_PREFIX);
+	assert_eq!(&hash_key[1..3], &4u16.to_be_bytes());
+	assert_eq!(&set_key[1..3], &4u16.to_be_bytes());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Replace the previous per-type SlateDB instances with one SlateDB database split by stable one-byte Nimbis storage segments.
- Add a SlateDB segment prefix extractor and route metadata, strings, hashes, lists, sets, sorted sets, and internal sequence bookkeeping through segment-prefixed keys.
- Batch complex-type metadata and data mutations through `WriteBatch` so collection updates commit atomically within the single DB.
- Update collection compaction filtering to inspect segmented keys and reclaim stale collection entries based on metadata type and generation.

## Implementation Notes

This updates the SlateDB dependency lockfile to a revision that supports segment extraction. The storage layer now persists the latest write sequence in an internal segment and serializes explicit-sequence batch commits so concurrent writes cannot submit a lower SlateDB `seqnum` after a higher one has already committed.

The sequence serialization fixes the invalid-sequence failure found while running concurrent multi-key INCR e2e coverage after the single-DB migration.

## Validation

- `just check`
- `cargo test -p nimbis-storage`
- `just build --release`
- `just e2e-test`